### PR TITLE
Removes the comment from the prepare.yml which breaks Ansible

### DIFF
--- a/tasks/prepare.yml
+++ b/tasks/prepare.yml
@@ -7,7 +7,7 @@
   get_url: url={{ graylog2_packages_url }} dest=/tmp/graylog2_repository.deb
 
 - name: Install Graylog2 repository
-  apt: deb=/tmp/graylog2_repository.deb state=installed force=yes # force because it might fail because of unauthenticated source
+  apt: deb=/tmp/graylog2_repository.deb state=installed force=yes
   register: install_repo
 
 - apt: update_cache=yes


### PR DESCRIPTION
So my previous PR contained an error which was detected later. I mistakenly added a comment before pushing which it seems Ansible breaks on.
