### PR TITLE
Allow users to specify what pieces they want to install 

### DIFF
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -155,3 +155,10 @@ graylog_server_wrapper: ''
 # Collector
 graylog_collector_inactive_threshold: '1m'
 graylog_collector_expiration_threshold: '14d'
+
+# Install Switches
+graylog_install_elasticsearch: true
+graylog_install_mongodb: true
+graylog_install_ngixn: true
+graylog_install_server: true
+graylog_install_web: true

--- a/meta/main.yml
+++ b/meta/main.yml
@@ -1,8 +1,11 @@
 ---
 dependencies:
-  - { role: greendayonfire.mongodb }
-  - { role: f500.elasticsearch }
-  - { role: jdauphant.nginx }
+  - role: greendayonfire.mongodb
+    when: graylog_install_mongodb
+  - role: f500.elasticsearch
+    when: graylog_install_elasticsearch
+  - role: jdauphant.nginx
+    when: graylog_install_nginx
 
 galaxy_info:
   author: Marius Sturm

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -2,5 +2,7 @@
 - include: prepare.yml
 
 - include: server.yml
+  when: graylog_install_server
 
 - include: web.yml
+  when: graylog_install_web


### PR DESCRIPTION
Not everyone wants to install everything on a single machine. These switches allows one to bypass installing the pieces they don't want.

For example, if I just want to install graylog-web:

```yaml
---
dependencies:
  - role: graylog.graylog
    graylog_install_server: false
    graylog_install_mongodb: false
    graylog_install_web: true
    graylog_install_nginx: false
    graylog_install_elasticsearch: false

```