### PR TITLE
Remove handler graylog-web

### DIFF
--- a/handlers/main.yml
+++ b/handlers/main.yml
@@ -2,5 +2,3 @@
 - name: restart graylog-server
   service: name=graylog-server state=restarted
 
-- name: restart graylog-web
-  service: name=graylog-web state=restarted


### PR DESCRIPTION
The service graylog-web was merged in the graylog-server in Graylog2

https://github.com/Graylog2/graylog2-web-interface