### PR TITLE
skipping nginx installation (graylog_install_nginx) does not work

### DIFF
--- a/meta/main.yml
+++ b/meta/main.yml
@@ -2,7 +2,7 @@
 dependencies:
   - { role: greendayonfire.mongodb }
   - { role: f500.elasticsearch }
-  - { role: jdauphant.nginx }
+  - { role: jdauphant.nginx, when: graylog_install_nginx }
 
 galaxy_info:
   author: Marius Sturm


### PR DESCRIPTION
The nginx installation roles is included unconditionally.