### PR TITLE
added network.host entry to elasticsearch.yml

### DIFF
--- a/templates/graylog.server.elasticsearch.yml.j2
+++ b/templates/graylog.server.elasticsearch.yml.j2
@@ -2,6 +2,7 @@ cluster.name: {{ graylog_elasticsearch_cluster_name }}
 node.name: {{ graylog_elasticsearch_node_name }}
 node.master: false
 node.data: false
+network.host: {{ graylog_elasticsearch_network_host }}
 transport.tcp.port: {{ graylog_elasticsearch_transport_tcp_port }}
 http.enabled: false
 discovery.zen.ping.unicast.hosts: {{ graylog_elasticsearch_discovery_zen_ping_unicast_hosts }}


### PR DESCRIPTION
This is needed if you grow the es cluster beyond one node.  Without
this, the internal graylog es client will attempt to peer with other
nodes using 127.0.0.1:9350 and the other es servers don't know how to
reach it.

I suggest 0.0.0.0 for a default value, but I didn't change it in defaults/main.yml because people might feel differently.