### PR TITLE
Update configuration to match version 2.1.1

### DIFF
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -104,16 +104,16 @@ graylog_ldap_connection_timeout:                       2000
 graylog_dashboard_widget_default_cache_time:           '10s'
 
 # Content packs
-graylog_content_packs_loader_enabled: true
-graylog_content_packs_dir: /usr/share/graylog-server/contentpacks
-graylog_content_packs_auto_load: ''
+graylog_content_packs_loader_enabled: 'True'
+graylog_content_packs_dir:            '/usr/share/graylog-server/contentpacks'
+graylog_content_packs_auto_load:      ''
 
 # Buffer
 graylog_udp_recvbuffer_sizes:                          1048576
 graylog_ring_size:                                     65536
 graylog_inputbuffer_ring_size:                         65536
 graylog_inputbuffer_processors:                        2
-graylog_inputbuffer_wait_strategy:                     blocking
+graylog_inputbuffer_wait_strategy:                     'blocking'
 graylog_outputbuffer_processor_keep_alive_time:        5000
 graylog_outputbuffer_processor_threads_core_pool_size: 3
 graylog_outputbuffer_processor_threads_max_pool_size:  30
@@ -144,7 +144,7 @@ graylog_http_proxy_uri:                    ''
 graylog_proxied_requests_thread_pool_size: 32
 
 # Web UI
-graylog_web_enable:                  True
+graylog_web_enable:                  'True'
 graylog_web_listen_uri:              'http://0.0.0.0:9000/'
 graylog_web_endpoint_uri:            ''
 graylog_enable_cors:                 'True'
@@ -164,6 +164,6 @@ graylog_server_args:          ''
 graylog_server_wrapper:       ''
 
 # Install Switches
-graylog_install_elasticsearch: True
-graylog_install_mongodb:       True
-graylog_install_nginx:         True
+graylog_install_elasticsearch: 'True'
+graylog_install_mongodb:       'True'
+graylog_install_nginx:         'True'

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -32,13 +32,12 @@ graylog_rest_enable_tls:                   'False'
 graylog_rest_tls_cert_file:                '/path/to/graylog.crt'
 graylog_rest_tls_key_file:                 '/path/to/graylog.key'
 graylog_rest_tls_key_password:             'secret'
-graylog_rest_max_chunk_size:               8192
 graylog_rest_max_header_size:              8192
 graylog_rest_max_initial_line_length:      4096
 graylog_rest_thread_pool_size:             16
-graylog_rest_worker_threads_max_pool_size: 16
 
 # Search
+graylog_elasticsearch_template_name:                    'graylog-internal'
 graylog_allow_leading_wildcard_searches:                'False'
 graylog_allow_highlighting:                             'False'
 graylog_elasticsearch_config_file:                      '/etc/graylog/server/elasticsearch.yml'
@@ -46,7 +45,7 @@ graylog_elasticsearch_shards:                           4
 graylog_elasticsearch_replicas:                         0
 graylog_elasticsearch_index_prefix:                     'graylog'
 graylog_elasticsearch_cluster_name:                     'graylog'
-graylog_elasticsearch_node_name:                        'graylog-server'
+graylog_elasticsearch_node_name_prefix:                 'graylog-'
 graylog_elasticsearch_transport_tcp_port:               9350
 graylog_elasticsearch_discovery_zen_ping_unicast_hosts: '127.0.0.1:9300'
 graylog_elasticsearch_network_host:                     ''
@@ -59,7 +58,6 @@ graylog_elasticsearch_disable_version_check:            'True'
 graylog_elasticsearch_http_enabled:                     'False'
 graylog_disable_index_optimization:                     'True'
 graylog_index_optimization_max_num_segments:            1
-graylog_disable_index_range_calculation:                'True'
 
 # Retention
 graylog_no_retention:                        'False'
@@ -71,28 +69,30 @@ graylog_elasticsearch_max_size_per_index:    1073741824
 graylog_elasticsearch_max_time_per_index:    '1d'
 
 # Processing
-graylog_processbuffer_processors:       5
-graylog_outputbuffer_processors:        3
-graylog_processor_wait_strategy:        'blocking'
-graylog_dead_letters_enabled:           'False'
-graylog_lb_recognition_period_seconds:  3
-graylog_stream_processing_max_faults:   3
-graylog_message_journal_enabled:        'True'
-graylog_message_journal_dir:            '/var/lib/graylog-server/journal'
-graylog_message_journal_max_age:        '12h'
-graylog_message_journal_max_size:       '5gb'
-graylog_message_journal_flush_age:      '1m'
-graylog_message_journal_flush_interval: 1000000
-graylog_message_journal_segment_age:    '1h'
-graylog_message_journal_segment_size:   '100mb'
-graylog_output_fault_count_threshold:   5
-graylog_output_fault_penalty_seconds:   30
-graylog_async_eventbus_processors:      2
+graylog_processbuffer_processors:         5
+graylog_outputbuffer_processors:          3
+graylog_processor_wait_strategy:          'blocking'
+graylog_dead_letters_enabled:             'False'
+graylog_lb_recognition_period_seconds:    3
+graylog_lb_throttle_threshold_percentage: 95
+graylog_stream_processing_max_faults:     3
+graylog_message_journal_enabled:          'True'
+graylog_message_journal_dir:              '/var/lib/graylog-server/journal'
+graylog_message_journal_max_age:          '12h'
+graylog_message_journal_max_size:         '5gb'
+graylog_message_journal_flush_age:        '1m'
+graylog_message_journal_flush_interval:   1000000
+graylog_message_journal_segment_age:      '1h'
+graylog_message_journal_segment_size:     '100mb'
+graylog_output_fault_count_threshold:     5
+graylog_output_fault_penalty_seconds:     30
+graylog_async_eventbus_processors:        2
 
 # Timeouts
 graylog_elasticsearch_cluster_discovery_timeout:       5000
 graylog_elasticsearch_discovery_initial_state_timeout: '3s'
 graylog_elasticsearch_request_timeout:                 '1m'
+graylog_index_ranges_cleanup_interval:                 '1h'
 graylog_stream_processing_timeout:                     2000
 graylog_output_module_timeout:                         10000
 graylog_stale_master_timeout:                          2000
@@ -102,6 +102,11 @@ graylog_http_read_timeout:                             '10s'
 graylog_http_write_timeout:                            '10s'
 graylog_ldap_connection_timeout:                       2000
 graylog_dashboard_widget_default_cache_time:           '10s'
+
+# Content packs
+graylog_content_packs_loader_enabled: true
+graylog_content_packs_dir: /usr/share/graylog-server/contentpacks
+graylog_content_packs_auto_load: ''
 
 # Buffer
 graylog_udp_recvbuffer_sizes:                          1048576
@@ -117,7 +122,6 @@ graylog_outputbuffer_processor_threads_max_pool_size:  30
 graylog_mongodb_uri:                                 'mongodb://127.0.0.1:27017/graylog'
 graylog_mongodb_max_connections:                     100
 graylog_mongodb_threads_allowed_to_block_multiplier: 5
-graylog_enable_metrics_collection:                   'False'
 
 # Drools
 graylog_rules_file: ''
@@ -136,27 +140,28 @@ graylog_transport_email_from_email:        ''
 graylog_transport_email_web_interface_url: ''
 
 # Proxy
-graylog_http_proxy_uri: ''
+graylog_http_proxy_uri:                    ''
+graylog_proxied_requests_thread_pool_size: 32
 
 # Web UI
-graylog_web_listen_uri:       'http://0.0.0.0:9000/'
-graylog_web_endpoint_uri:     ''
-graylog_enable_cors:          'False'
-graylog_enable_gzip:          'False'
-graylog_web_enable_tls:       'False'
-graylog_web_tls_cert_file:    ''
-graylog_web_tls_key_file:     ''
-graylog_web_tls_key_password: ''
+graylog_web_enable:                  True
+graylog_web_listen_uri:              'http://0.0.0.0:9000/'
+graylog_web_endpoint_uri:            ''
+graylog_enable_cors:                 'True'
+graylog_enable_gzip:                 'True'
+graylog_web_enable_tls:              'False'
+graylog_web_tls_cert_file:           ''
+graylog_web_tls_key_file:            ''
+graylog_web_tls_key_password:        ''
+graylog_web_max_header_size:         8192
+graylog_web_max_initial_line_length: 4096
+graylog_web_thread_pool_size:        16
 
 # JVM
 graylog_gc_warning_threshold: '1s'
 graylog_server_java_opts:     '-Djava.net.preferIPv4Stack=true -Xms1500m -Xmx1500m -XX:NewRatio=1 -server -XX:+ResizeTLAB -XX:+UseConcMarkSweepGC -XX:+CMSConcurrentMTEnabled -XX:+CMSClassUnloadingEnabled -XX:+UseParNewGC -XX:-OmitStackTraceInFastThrow'
 graylog_server_args:          ''
 graylog_server_wrapper:       ''
-
-# Collector
-graylog_collector_inactive_threshold:   '1m'
-graylog_collector_expiration_threshold: '14d'
 
 # Install Switches
 graylog_install_elasticsearch: True

--- a/templates/graylog.server.conf.j2
+++ b/templates/graylog.server.conf.j2
@@ -1,57 +1,157 @@
-# Cluster settings
-## If you are running more than one instances of graylog-server you have to select one of these
-## instances as master. The master will perform some periodical tasks that non-masters won't perform.
+############################
+# GRAYLOG CONFIGURATION FILE
+############################
+#
+# This is the Graylog configuration file. The file has to use ISO 8859-1/Latin-1 character encoding.
+# Characters that cannot be directly represented in this encoding can be written using Unicode escapes
+# as defined in https://docs.oracle.com/javase/specs/jls/se8/html/jls-3.html#jls-3.3, using the \u prefix.
+# For example, \u002c.
+#
+# * Entries are generally expected to be a single line of the form, one of the following:
+#
+# propertyName=propertyValue
+# propertyName:propertyValue
+#
+# * White space that appears between the property name and property value is ignored,
+#   so the following are equivalent:
+#
+# name=Stephen
+# name = Stephen
+#
+# * White space at the beginning of the line is also ignored.
+#
+# * Lines that start with the comment characters ! or # are ignored. Blank lines are also ignored.
+#
+# * The property value is generally terminated by the end of the line. White space following the
+#   property value is not ignored, and is treated as part of the property value.
+#
+# * A property value can span several lines if each line is terminated by a backslash (‘\’) character.
+#   For example:
+#
+# targetCities=\
+#         Detroit,\
+#         Chicago,\
+#         Los Angeles
+#
+#   This is equivalent to targetCities=Detroit,Chicago,Los Angeles (white space at the beginning of lines is ignored).
+#
+# * The characters newline, carriage return, and tab can be inserted with characters \n, \r, and \t, respectively.
+#
+# * The backslash character must be escaped as a double backslash. For example:
+#
+# path=c:\\docs\\doc1
+#
+
+# If you are running more than one instances of Graylog server you have to select one of these
+# instances as master. The master will perform some periodical tasks that non-masters won't perform.
 is_master = {{ graylog_is_master }}
 
-## The auto-generated node ID will be stored in this file and read after restarts. It is a good idea
-## to use an absolute file path here if you are starting graylog-server from init scripts or similar.
+# The auto-generated node ID will be stored in this file and read after restarts. It is a good idea
+# to use an absolute file path here if you are starting Graylog server from init scripts or similar.
 node_id_file = {{ graylog_node_id_file }}
 
-# Access secrets
-## You MUST set a secret to secure/pepper the stored user passwords here. Use at least 64 characters.
-## Generate one by using for example: pwgen -N 1 -s 96
+# You MUST set a secret to secure/pepper the stored user passwords here. Use at least 64 characters.
+# Generate one by using for example: pwgen -N 1 -s 96
 password_secret = {{ graylog_password_secret }}
 
-## the default root user is named 'admin'
+# The default root user is named 'admin'
 root_username = {{ graylog_root_username }}
 
-## You MUST specify a hash password for the root user (which you only need to initially set up the
-## system and in case you lose connectivity to your authentication backend)
-## This password cannot be changed using the API or via the web interface. If you need to change it,
-## modify it in this file.
-## Create one by using for example: echo -n yourpassword | shasum -a 256
-## and put the resulting hash value into the following line
+# You MUST specify a hash password for the root user (which you only need to initially set up the
+# system and in case you lose connectivity to your authentication backend)
+# This password cannot be changed using the API or via the web interface. If you need to change it,
+# modify it in this file.
+# Create one by using for example: echo -n yourpassword | shasum -a 256
+# and put the resulting hash value into the following line
 root_password_sha2 = {{ graylog_root_password_sha2 }}
 
 # The email address of the root user.
 # Default is empty
 root_email = {{ graylog_root_email }}
 
-# The time zone setting of the root user.
+# The time zone setting of the root user. See http://www.joda.org/joda-time/timezones.html for a list of valid time zones.
 # Default is UTC
 root_timezone = {{ graylog_root_timezone }}
 
-# Plugins
-## Set plugin directory here (relative or absolute)
+# Set plugin directory here (relative or absolute)
 plugin_dir = {{ graylog_plugin_dir }}
 
-# REST interface
-## REST API listen URI. Must be reachable by other graylog-server nodes if you run a cluster.
+# REST API listen URI. Must be reachable by other Graylog server nodes if you run a cluster.
+# When using Graylog Collectors, this URI will be used to receive heartbeat messages and must be accessible for all collectors.
 rest_listen_uri = {{ graylog_rest_listen_uri }}
 
-# Web interface
+# REST API transport address. Defaults to the value of graylog_rest_listen_uri. Exception: If graylog_rest_listen_uri
+# is set to a wildcard IP address (0.0.0.0) the first non-loopback IPv4 system address is used.
+# If set, this will be promoted in the cluster discovery APIs, so other nodes may try to connect on
+# this address and it is used to generate URLs addressing entities in the REST API. (see graylog_rest_listen_uri)
+# You will need to define this, if your Graylog server is running behind a HTTP proxy that is rewriting
+# the scheme, host name or URI.
+# This must not contain a wildcard address (0.0.0.0).
+{% if graylog_rest_transport_uri %}
+rest_transport_uri = {{ graylog_rest_transport_uri }}
+{% else %}
+#rest_transport_uri = http://192.168.1.1:12900/
+{% endif %}
+
+# Enable CORS headers for REST API. This is necessary for JS-clients accessing the server directly.
+# If these are disabled, modern browsers will not be able to retrieve resources from the server.
+# This is enabled by default. Uncomment the next line to disable it.
+rest_enable_cors = {{ graylog_rest_enable_cors }}
+
+# Enable GZIP support for REST API. This compresses API responses and therefore helps to reduce
+# overall round trip times. This is enabled by default. Uncomment the next line to disable it.
+rest_enable_gzip = {{ graylog_rest_enable_gzip }}
+
+# Enable HTTPS support for the REST API. This secures the communication with the REST API with
+# TLS to prevent request forgery and eavesdropping. This is disabled by default. Uncomment the
+# next line to enable it.
+rest_enable_tls = {{ graylog_rest_enable_tls }}
+
+# The X.509 certificate chain file in PEM format to use for securing the REST API.
+rest_tls_cert_file = {{ graylog_rest_tls_cert_file }}
+
+# The PKCS#8 private key file in PEM format to use for securing the REST API.
+rest_tls_key_file = {{ graylog_rest_tls_key_file }}
+
+# The password to unlock the private key used for securing the REST API.
+rest_tls_key_password = {{ graylog_rest_tls_key_password }}
+
+# The maximum size of the HTTP request headers in bytes.
+rest_max_header_size = {{ graylog_rest_max_header_size }}
+
+# The maximal length of the initial HTTP/1.1 line in bytes.
+rest_max_initial_line_length = {{ graylog_rest_max_initial_line_length }}
+
+# The size of the thread pool used exclusively for serving the REST API.
+rest_thread_pool_size = {{ graylog_rest_thread_pool_size }}
+
+# Comma separated list of trusted proxies that are allowed to set the client address with X-Forwarded-For
+# header. May be subnets, or hosts.
+#trusted_proxies = 127.0.0.1/32, 0:0:0:0:0:0:0:1/128
+
+# Enable the embedded Graylog web interface.
+# Default: true
+web_enable = {{ graylog_web_enable }}
+
+# Web interface listen URI.
+# Configuring a path for the URI here effectively prefixes all URIs in the web interface. This is a replacement
+# for the application.context configuration parameter in pre-2.0 versions of the Graylog web interface.
 web_listen_uri = {{ graylog_web_listen_uri }}
 
 # Web interface endpoint URI. This setting can be overriden on a per-request basis with the X-Graylog-Server-URL header.
 # Default: $rest_transport_uri
+{% if graylog_web_endpoint_uri %}
 web_endpoint_uri = {{ graylog_web_endpoint_uri }}
+{% else %}
+#web_endpoint_uri =
+{% endif %}
 
 # Enable CORS headers for the web interface. This is necessary for JS-clients accessing the server directly.
 # If these are disabled, modern browsers will not be able to retrieve resources from the server.
 web_enable_cors = {{ graylog_enable_cors }}
 
 # Enable/disable GZIP support for the web interface. This compresses HTTP responses and therefore helps to reduce
-# overall round trip times.
+# overall round trip times. This is enabled by default. Uncomment the next line to disable it.
 web_enable_gzip = {{ graylog_enable_gzip }}
 
 # Enable HTTPS support for the web interface. This secures the communication of the web browser with the web interface
@@ -68,160 +168,153 @@ web_tls_key_file = {{ graylog_web_tls_key_file }}
 # The password to unlock the private key used for securing the web interface.
 web_tls_key_password = {{ graylog_web_tls_key_password }}
 
-## REST API transport address. Defaults to the value of graylog_rest_listen_uri. Exception: If graylog_rest_listen_uri
-## is set to a wildcard IP address (0.0.0.0) the first non-loopback IPv4 system address is used.
-## This will be promoted in the cluster discovery APIs and other nodes may try to connect on this
-## address. (see graylog_rest_listen_uri)
-{% if graylog_rest_transport_uri %}
-rest_transport_uri = {{ graylog_rest_transport_uri }}
-{% endif %}
-
-## Enable CORS headers for REST api. This is necessary for JS-clients accessing the server directly.
-## If these are disabled, modern browsers will not be able to retrieve resources from the server.
-## This is disabled by default. Uncomment the next line to enable it.
-rest_enable_cors = {{ graylog_rest_enable_cors }}
-
-## Enable GZIP support for REST api. This compresses API responses and therefore helps to reduce
-## overall round trip times.
-rest_enable_gzip = {{ graylog_rest_enable_gzip }}
-
-# Enable HTTPS support for the REST API. This secures the communication with the REST API with
-# TLS to prevent request forgery and eavesdropping. This is disabled by default. Uncomment the
-# next line to enable it.
-rest_enable_tls = {{ graylog_rest_enable_tls }}
-
-# The X.509 certificate file to use for securing the REST API.
-rest_tls_cert_file = {{ graylog_rest_tls_cert_file }}
-
-# The private key to use for securing the REST API.
-rest_tls_key_file = {{ graylog_rest_tls_key_file }}
-
-# The password to unlock the private key used for securing the REST API.
-rest_tls_key_password = {{ graylog_rest_tls_key_password }}
-
-# The maximum size of a single HTTP chunk in bytes.
-rest_max_chunk_size = {{ graylog_rest_max_chunk_size }}
-
 # The maximum size of the HTTP request headers in bytes.
-rest_max_header_size = {{ graylog_rest_max_header_size }}
+web_max_header_size = {{ graylog_web_max_header_size }}
 
 # The maximal length of the initial HTTP/1.1 line in bytes.
-rest_max_initial_line_length = {{ graylog_rest_max_initial_line_length }}
+web_max_initial_line_length = {{ graylog_web_max_initial_line_length }}
 
-# The size of the execution handler thread pool used exclusively for serving the REST API.
-rest_thread_pool_size = {{ graylog_rest_thread_pool_size }}
+# The size of the thread pool used exclusively for serving the web interface.
+web_thread_pool_size = {{ graylog_web_thread_pool_size }}
 
-# The size of the worker thread pool used exclusively for serving the REST API.
-rest_worker_threads_max_pool_size = {{ graylog_rest_worker_threads_max_pool_size }}
-
-## Embedded Elasticsearch configuration file
-## pay attention to the working directory of the server, maybe use an absolute path here
+# Configuration file for the embedded Elasticsearch instance in Graylog.
+# Pay attention to the working directory of the server, maybe use an absolute path here.
+# Default: empty
 elasticsearch_config_file = {{ graylog_elasticsearch_config_file }}
 
-## Graylog will use multiple indices to store documents in. You can configured the strategy it uses to determine
-## when to rotate the currently active write index.
-## It supports multiple rotation strategies:
-##  - "count" of messages per index, use elasticsearch_max_docs_per_index below to configure
-##  - "size" per index, use elasticsearch_max_size_per_index below to configure
-## valid values are "count", "size" and "time", default is "count"
+# Graylog will use multiple indices to store documents in. You can configured the strategy it uses to determine
+# when to rotate the currently active write index.
+# It supports multiple rotation strategies:
+#   - "count" of messages per index, use elasticsearch_max_docs_per_index below to configure
+#   - "size" per index, use elasticsearch_max_size_per_index below to configure
+# valid values are "count", "size" and "time", default is "count"
+#
+# ATTENTION: These settings have been moved to the database in 2.0. When you upgrade, make sure to set these
+#            to your previous 1.x settings so they will be migrated to the database!
 rotation_strategy = {{ graylog_rotation_strategy }}
 
-## (Approximate) maximum number of documents in an Elasticsearch index before a new index
-## is being created, also see no_retention and elasticsearch_max_number_of_indices.
-## Configure this if you used 'rotation_strategy = count' above.
+# (Approximate) maximum number of documents in an Elasticsearch index before a new index
+# is being created, also see no_retention and elasticsearch_max_number_of_indices.
+# Configure this if you used 'rotation_strategy = count' above.
+#
+# ATTENTION: These settings have been moved to the database in 2.0. When you upgrade, make sure to set these
+#            to your previous 1.x settings so they will be migrated to the database!
 elasticsearch_max_docs_per_index = {{ graylog_elasticsearch_max_docs_per_index }}
 
-## (Approximate) maximum size in bytes per Elasticsearch index on disk before a new index is being created, also see
-## no_retention and elasticsearch_max_number_of_indices. Default is 1GB.
-## Configure this if you used 'rotation_strategy = size' above.
+# (Approximate) maximum size in bytes per Elasticsearch index on disk before a new index is being created, also see
+# no_retention and elasticsearch_max_number_of_indices. Default is 1GB.
+# Configure this if you used 'rotation_strategy = size' above.
+#
+# ATTENTION: These settings have been moved to the database in 2.0. When you upgrade, make sure to set these
+#            to your previous 1.x settings so they will be migrated to the database!
 elasticsearch_max_size_per_index = {{ graylog_elasticsearch_max_size_per_index }}
 
-## (Approximate) maximum time before a new Elasticsearch index is being created, also see
-## no_retention and elasticsearch_max_number_of_indices. Default is 1 day.
-## Configure this if you used 'rotation_strategy = time' above.
-## Please note that this rotation period does not look at the time specified in the received messages, but is
-## using the real clock value to decide when to rotate the index!
-## Specify the time using a duration and a suffix indicating which unit you want:
-## 1d == 1 day
-## 12h == 12 hours
-## Permitted suffixes are: d for day, h for hour, m for minute, s for second.
+# (Approximate) maximum time before a new Elasticsearch index is being created, also see
+# no_retention and elasticsearch_max_number_of_indices. Default is 1 day.
+# Configure this if you used 'rotation_strategy = time' above.
+# Please note that this rotation period does not look at the time specified in the received messages, but is
+# using the real clock value to decide when to rotate the index!
+# Specify the time using a duration and a suffix indicating which unit you want:
+#  1w  = 1 week
+#  1d  = 1 day
+#  12h = 12 hours
+# Permitted suffixes are: d for day, h for hour, m for minute, s for second.
+#
+# ATTENTION: These settings have been moved to the database in 2.0. When you upgrade, make sure to set these
+#            to your previous 1.x settings so they will be migrated to the database!
 elasticsearch_max_time_per_index = {{ graylog_elasticsearch_max_time_per_index }}
 
 # Disable checking the version of Elasticsearch for being compatible with this Graylog release.
 # WARNING: Using Graylog with unsupported and untested versions of Elasticsearch may lead to data loss!
 elasticsearch_disable_version_check = {{ graylog_elasticsearch_disable_version_check }}
 
-## Disable message retention on this node, i. e. disable Elasticsearch index rotation.
+# Disable message retention on this node, i. e. disable Elasticsearch index rotation.
 no_retention = {{ graylog_no_retention }}
 
-## How many indices do you want to keep?
-## elasticsearch_max_number_of_indices*elasticsearch_max_docs_per_index=total number of messages in your setup
+# How many indices do you want to keep?
+#
+# ATTENTION: These settings have been moved to the database in 2.0. When you upgrade, make sure to set these
+#            to your previous 1.x settings so they will be migrated to the database!
 elasticsearch_max_number_of_indices = {{ graylog_elasticsearch_max_number_of_indices }}
 
-## Decide what happens with the oldest indices when the maximum number of indices is reached.
-## The following strategies are availble:
-##  - delete ## Deletes the index completely (Default)
-##  - close ## Closes the index and hides it from the system. Can be re-opened later.
+# Decide what happens with the oldest indices when the maximum number of indices is reached.
+# The following strategies are availble:
+#   - delete # Deletes the index completely (Default)
+#   - close # Closes the index and hides it from the system. Can be re-opened later.
+#
+# ATTENTION: These settings have been moved to the database in 2.0. When you upgrade, make sure to set these
+#            to your previous 1.x settings so they will be migrated to the database!
 retention_strategy = {{ graylog_elasticsearch_retention_strategy }}
 
-## How many Elasticsearch shards and replicas should be used per index? Note that this only applies to newly created indices.
+# How many Elasticsearch shards and replicas should be used per index? Note that this only applies to newly created indices.
 elasticsearch_shards = {{ graylog_elasticsearch_shards }}
 elasticsearch_replicas = {{ graylog_elasticsearch_replicas }}
 
-## Prefix for all Elasticsearch indices and index aliases managed by Graylog.
+# Prefix for all Elasticsearch indices and index aliases managed by Graylog.
 elasticsearch_index_prefix = {{ graylog_elasticsearch_index_prefix }}
 
-# Search options
-## Do you want to allow searches with leading wildcards? This can be extremely resource hungry and should only
-## be enabled with care. See also: http://graylog.org/resources/documentation/general/queries
+# Name of the Elasticsearch index template used by Graylog to apply the mandatory index mapping.
+# # Default: graylog-internal
+elasticsearch_template_name = {{ graylog_elasticsearch_template_name }}
+
+# Do you want to allow searches with leading wildcards? This can be extremely resource hungry and should only
+# be enabled with care. See also: http://docs.graylog.org/en/2.1/pages/queries.html
 allow_leading_wildcard_searches = {{ graylog_allow_leading_wildcard_searches }}
 
-## Do you want to allow searches to be highlighted? Depending on the size of your messages this can be memory hungry and
-## should only be enabled after making sure your Elasticsearch cluster has enough memory.
+# Do you want to allow searches to be highlighted? Depending on the size of your messages this can be memory hungry and
+# should only be enabled after making sure your Elasticsearch cluster has enough memory.
 allow_highlighting = {{ graylog_allow_highlighting }}
 
-## settings to be passed to elasticsearch's client (overriding those in the provided elasticsearch_config_file)
-## all these
-## this must be the same as for your Elasticsearch cluster
+# settings to be passed to elasticsearch's client (overriding those in the provided elasticsearch_config_file)
+# all these
+# this must be the same as for your Elasticsearch cluster
 elasticsearch_cluster_name = {{ graylog_elasticsearch_cluster_name }}
 
-## you could also leave this out, but makes it easier to identify the graylog client instance
-elasticsearch_node_name = {{ graylog_elasticsearch_node_name }}
+# The prefix being used to generate the Elasticsearch node name which makes it easier to identify the specific Graylog
+# server running the embedded Elasticsearch instance. The node name will be constructed by concatenating this prefix
+# and the Graylog node ID (see node_id_file), for example "graylog-17052010-1234-5678-abcd-1337cafebabe".
+# Default: graylog-
+elasticsearch_node_name_prefix = {{ graylog_elasticsearch_node_name_prefix }}
 
-# Elasticsearch
-## we don't want the graylog server to store any data, or be master node
+# A comma-separated list of Elasticsearch nodes which Graylog is using to connect to the Elasticsearch cluster,
+# see https://www.elastic.co/guide/en/elasticsearch/reference/2.3/modules-discovery-zen.html for details.
+# Default: 127.0.0.1
+elasticsearch_discovery_zen_ping_unicast_hosts = {{ graylog_elasticsearch_discovery_zen_ping_unicast_hosts }}
+
+# Use multiple Elasticsearch nodes as seed
+#elasticsearch_discovery_zen_ping_unicast_hosts = 198.51.100.23:9300, 198.51.100.42:9300
+
+# we don't want the Graylog server to store any data, or be master node
 elasticsearch_node_master = false
 elasticsearch_node_data = false
 
-## use a different port if you run multiple Elasticsearch nodes on one machine
+# use a different port if you run multiple Elasticsearch nodes on one machine
 elasticsearch_transport_tcp_port = {{ graylog_elasticsearch_transport_tcp_port }}
 
-## we don't need to run the embedded HTTP server here
+# we don't need to run the embedded HTTP server here
 elasticsearch_http_enabled = {{ graylog_elasticsearch_http_enabled }}
 
-elasticsearch_discovery_zen_ping_unicast_hosts = {{ graylog_elasticsearch_discovery_zen_ping_unicast_hosts }}
-
-## Change the following setting if you are running into problems with timeouts during Elasticsearch cluster discovery.
-## The setting is specified in milliseconds, the default is 5000ms (5 seconds).
+# Change the following setting if you are running into problems with timeouts during Elasticsearch cluster discovery.
+# The setting is specified in milliseconds, the default is 5000ms (5 seconds).
 elasticsearch_cluster_discovery_timeout = {{ graylog_elasticsearch_cluster_discovery_timeout }}
 
-## the following settings allow to change the bind addresses for the Elasticsearch client in graylog
-## these settings are empty by default, letting Elasticsearch choose automatically,
-## override them here or in the 'elasticsearch_config_file' if you need to bind to a special address
-## refer to http://www.elasticsearch.org/guide/en/elasticsearch/reference/0.90/modules-network.html
-## for special values here
+# the following settings allow to change the bind addresses for the Elasticsearch client in Graylog
+# these settings are empty by default, letting Elasticsearch choose automatically,
+# override them here or in the 'elasticsearch_config_file' if you need to bind to a special address
+# refer to https://www.elastic.co/guide/en/elasticsearch/reference/2.3/modules-network.html
+# for special values here
 elasticsearch_network_host = {{ graylog_elasticsearch_network_host }}
 elasticsearch_network_bind_host = {{ graylog_elasticsearch_network_bind_host }}
 elasticsearch_network_publish_host = {{ graylog_elasticsearch_network_publish_host }}
 
-## The total amount of time discovery will look for other Elasticsearch nodes in the cluster
-## before giving up and declaring the current node master.
+# The total amount of time discovery will look for other Elasticsearch nodes in the cluster
+# before giving up and declaring the current node master.
 elasticsearch_discovery_initial_state_timeout = {{ graylog_elasticsearch_discovery_initial_state_timeout }}
 
-## Analyzer (tokenizer) to use for message and full_message field. The "standard" filter usually is a good idea.
-## All supported analyzers are: standard, simple, whitespace, stop, keyword, pattern, language, snowball, custom
-## Elasticsearch documentation: http://www.elasticsearch.org/guide/reference/index-modules/analysis/
-## Note that this setting only takes effect on newly created indices.
+# Analyzer (tokenizer) to use for message and full_message field. The "standard" filter usually is a good idea.
+# All supported analyzers are: standard, simple, whitespace, stop, keyword, pattern, language, snowball, custom
+# Elasticsearch documentation: https://www.elastic.co/guide/en/elasticsearch/reference/2.3/analysis.html
+# Note that this setting only takes effect on newly created indices.
 elasticsearch_analyzer = {{ graylog_elasticsearch_analyzer }}
 
 # Global request timeout for Elasticsearch requests (e. g. during search, index creation, or index time-range
@@ -229,16 +322,21 @@ elasticsearch_analyzer = {{ graylog_elasticsearch_analyzer }}
 # Default: 1m
 elasticsearch_request_timeout = {{ graylog_elasticsearch_request_timeout }}
 
-## Batch size for the Elasticsearch output. This is the maximum (!) number of messages the Elasticsearch output
-## module will get at once and write to Elasticsearch in a batch call. If the configured batch size has not been
-## reached within output_flush_interval seconds, everything that is available will be flushed at once. Remember
-## that every outputbuffer processor manages its own batch and performs its own batch write calls.
-## ("graylog_outputbuffer_processors" variable)
+# Time interval for index range information cleanups. This setting defines how often stale index range information
+# is being purged from the database.
+# Default: 1h
+index_ranges_cleanup_interval = {{ graylog_index_ranges_cleanup_interval }}
+
+# Batch size for the Elasticsearch output. This is the maximum (!) number of messages the Elasticsearch output
+# module will get at once and write to Elasticsearch in a batch call. If the configured batch size has not been
+# reached within output_flush_interval seconds, everything that is available will be flushed at once. Remember
+# that every outputbuffer processor manages its own batch and performs its own batch write calls.
+# ("outputbuffer_processors" variable)
 output_batch_size = {{ graylog_elasticsearch_output_batch_size }}
 
-## Flush interval (in seconds) for the Elasticsearch output. This is the maximum amount of time between two
-## batches of messages written to Elasticsearch. It is only effective at all if your minimum number of messages
-## for this time period is less than output_batch_size * graylog_outputbuffer_processors.
+# Flush interval (in seconds) for the Elasticsearch output. This is the maximum amount of time between two
+# batches of messages written to Elasticsearch. It is only effective at all if your minimum number of messages
+# for this time period is less than output_batch_size * outputbuffer_processors.
 output_flush_interval = {{ graylog_elasticsearch_output_flush_interval }}
 
 # As stream outputs are loaded only on demand, an output which is failing to initialize will be tried over and
@@ -247,9 +345,8 @@ output_flush_interval = {{ graylog_elasticsearch_output_flush_interval }}
 output_fault_count_threshold = {{ graylog_output_fault_count_threshold }}
 output_fault_penalty_seconds = {{ graylog_output_fault_penalty_seconds }}
 
-# Processors
-## The number of parallel running processors.
-## Raise this number if your buffers are filling up.
+# The number of parallel running processors.
+# Raise this number if your buffers are filling up.
 processbuffer_processors = {{ graylog_processbuffer_processors }}
 outputbuffer_processors = {{ graylog_outputbuffer_processors }}
 
@@ -257,24 +354,23 @@ outputbuffer_processor_keep_alive_time = {{ graylog_outputbuffer_processor_keep_
 outputbuffer_processor_threads_core_pool_size = {{ graylog_outputbuffer_processor_threads_core_pool_size }}
 outputbuffer_processor_threads_max_pool_size = {{ graylog_outputbuffer_processor_threads_max_pool_size }}
 
-## UDP receive buffer size for all message inputs (e. g. SyslogUDPInput).
+# UDP receive buffer size for all message inputs (e. g. SyslogUDPInput).
 udp_recvbuffer_sizes = {{ graylog_udp_recvbuffer_sizes }}
 
-## Wait strategy describing how buffer processors wait on a cursor sequence. (default: sleeping)
-## Possible types:
-## - yielding
-##    Compromise between performance and CPU usage.
-## - sleeping
-##    Compromise between performance and CPU usage. Latency spikes can occur after quiet periods.
-## - blocking
-##    High throughput, low latency, higher CPU usage.
-## - busy_spinning
-##    Avoids syscalls which could introduce latency jitter. Best when threads can be bound to specific CPU cores.
+# Wait strategy describing how buffer processors wait on a cursor sequence. (default: sleeping)
+# Possible types:
+#  - yielding
+#     Compromise between performance and CPU usage.
+#  - sleeping
+#     Compromise between performance and CPU usage. Latency spikes can occur after quiet periods.
+#  - blocking
+#     High throughput, low latency, higher CPU usage.
+#  - busy_spinning
+#     Avoids syscalls which could introduce latency jitter. Best when threads can be bound to specific CPU cores.
 processor_wait_strategy = {{ graylog_processor_wait_strategy }}
 
 # Size of internal ring buffers. Raise this if raising outputbuffer_processors does not help anymore.
 # For optimum performance your LogMessage objects in the ring buffer should fit in your CPU L3 cache.
-# Start server with --statistics flag to see buffer utilization.
 # Must be a power of 2. (512, 1024, 2048, ...)
 ring_size = {{ graylog_ring_size }}
 
@@ -287,6 +383,11 @@ message_journal_enabled = {{ graylog_message_journal_enabled }}
 
 # The directory which will be used to store the message journal. The directory must me exclusively used by Graylog and
 # must not contain any other files than the ones created by Graylog itself.
+#
+# ATTENTION:
+#   If you create a seperate partition for the journal files and use a file system creating directories like 'lost+found'
+#   in the root directory, you need to create a sub directory for your journal.
+#   Otherwise Graylog will log an error message that the journal is corrupt and Graylog will not start.
 message_journal_dir = {{ graylog_message_journal_dir }}
 
 # Journal hold messages before they could be written to Elasticsearch.
@@ -302,19 +403,21 @@ message_journal_segment_size = {{ graylog_message_journal_segment_size }}
 # Number of threads used exclusively for dispatching internal events. Default is 2.
 async_eventbus_processors = {{ graylog_async_eventbus_processors }}
 
-# Load balancing
-## How many seconds to wait between marking node as DEAD for possible load balancers and starting the actual
-## shutdown process. Set to 0 if you have no status checking load balancers in front.
+# How many seconds to wait between marking node as DEAD for possible load balancers and starting the actual
+# shutdown process. Set to 0 if you have no status checking load balancers in front.
 lb_recognition_period_seconds = {{ graylog_lb_recognition_period_seconds }}
 
-# Stream processing
-## Every message is matched against the configured streams and it can happen that a stream contains rules which
-## take an unusual amount of time to run, for example if its using regular expressions that perform excessive backtracking.
-## This will impact the processing of the entire server. To keep such misbehaving stream rules from impacting other
-## streams, Graylog limits the execution time for each stream.
-## The default values are noted below, the timeout is in milliseconds.
-## If the stream matching for one stream took longer than the timeout value, and this happened more than "max_faults" times
-## that stream is disabled and a notification is shown in the web interface.
+# Journal usage percentage that triggers requesting throttling for this server node from load balancers. The feature is
+# disabled if not set.
+lb_throttle_threshold_percentage = {{ graylog_lb_throttle_threshold_percentage }}
+
+# Every message is matched against the configured streams and it can happen that a stream contains rules which
+# take an unusual amount of time to run, for example if its using regular expressions that perform excessive backtracking.
+# This will impact the processing of the entire server. To keep such misbehaving stream rules from impacting other
+# streams, Graylog limits the execution time for each stream.
+# The default values are noted below, the timeout is in milliseconds.
+# If the stream matching for one stream took longer than the timeout value, and this happened more than "max_faults" times
+# that stream is disabled and a notification is shown in the web interface.
 stream_processing_timeout = {{ graylog_stream_processing_timeout }}
 stream_processing_max_faults = {{ graylog_stream_processing_max_faults }}
 
@@ -322,32 +425,42 @@ stream_processing_max_faults = {{ graylog_stream_processing_max_faults }}
 # and alarms are being sent.
 alert_check_interval = {{ graylog_alert_check_interval }}
 
-## Since 0.21 the graylog server supports pluggable output modules. This means a single message can be written to multiple
-## outputs. The next setting defines the timeout for a single output module, including the default output module where all
-## messages end up. This setting is specified in milliseconds.
-
-## Time in milliseconds to wait for all message outputs to finish writing a single message.
+# Since 0.21 the Graylog server supports pluggable output modules. This means a single message can be written to multiple
+# outputs. The next setting defines the timeout for a single output module, including the default output module where all
+# messages end up.
+#
+# Time in milliseconds to wait for all message outputs to finish writing a single message.
 output_module_timeout = {{ graylog_output_module_timeout }}
 
-## Time in milliseconds after which a detected stale master node is being rechecked on startup.
+# Time in milliseconds after which a detected stale master node is being rechecked on startup.
 stale_master_timeout = {{ graylog_stale_master_timeout }}
 
-## Time in milliseconds which Graylog is waiting for all threads to stop on shutdown.
+# Time in milliseconds which Graylog is waiting for all threads to stop on shutdown.
 shutdown_timeout = {{ graylog_shutdown_timeout }}
 
 # MongoDB connection string
-# See http://docs.mongodb.org/manual/reference/connection-string/ for details
+# See https://docs.mongodb.com/manual/reference/connection-string/ for details
+# mongodb_uri = mongodb://localhost/graylog
+
+# Authenticate against the MongoDB server
+#mongodb_uri = mongodb://grayloguser:secret@localhost:27017/graylog
+
+# Use a replica set instead of a single host
+#mongodb_uri = mongodb://grayloguser:secret@localhost:27017,localhost:27018,localhost:27019/graylog
 mongodb_uri = {{ graylog_mongodb_uri }}
 
-## Raise this according to the maximum connections your MongoDB server can handle if you encounter MongoDB connection problems.
+# Increase this value according to the maximum connections your MongoDB server can handle from a single client
+# if you encounter MongoDB connection problems.
 mongodb_max_connections = {{ graylog_mongodb_max_connections }}
 
-## Number of threads allowed to be blocked by MongoDB connections multiplier. Default: 5
-## If graylog_mongodb_max_connections is 100, and graylog_mongodb_threads_allowed_to_block_multiplier is 5, then 500 threads can block. More than that and an exception will be thrown.
-## http://api.mongodb.org/java/current/com/mongodb/MongoOptions.html#threadsAllowedToBlockForConnectionMultiplier
+# Number of threads allowed to be blocked by MongoDB connections multiplier. Default: 5
+# If mongodb_max_connections is 100, and mongodb_threads_allowed_to_block_multiplier is 5,
+# then 500 threads can block. More than that and an exception will be thrown.
+# http://api.mongodb.com/java/current/com/mongodb/MongoOptions.html#threadsAllowedToBlockForConnectionMultiplier
 mongodb_threads_allowed_to_block_multiplier = {{ graylog_mongodb_threads_allowed_to_block_multiplier }}
 
 # Drools Rule File (Use to rewrite incoming log messages)
+# See: http://docs.graylog.org/en/2.1/pages/drools.html
 rules_file = {{ graylog_rules_file }}
 
 # Email transport
@@ -362,8 +475,8 @@ transport_email_auth_password = {{ graylog_transport_email_auth_password }}
 transport_email_subject_prefix = {{ graylog_transport_email_subject_prefix }}
 transport_email_from_email = {{ graylog_transport_email_from_email }}
 
-## Specify and uncomment this if you want to include links to the stream in your stream alert mails.
-## This should define the fully qualified base url to your web interface exactly the same way as it is accessed by your users.
+# Specify and uncomment this if you want to include links to the stream in your stream alert mails.
+# This should define the fully qualified base url to your web interface exactly the same way as it is accessed by your users.
 transport_email_web_interface_url = {{ graylog_transport_email_web_interface_url }}
 
 # The default connect timeout for outgoing HTTP connections.
@@ -381,7 +494,7 @@ http_read_timeout = {{ graylog_http_read_timeout }}
 # Default: 10s
 http_write_timeout = {{ graylog_http_write_timeout }}
 
-# HTTP proxy for outgoing HTTP calls
+# HTTP proxy for outgoing HTTP connections
 # http_proxy_uri = {{ graylog_http_proxy_uri }}
 
 # Disable the optimization of Elasticsearch indices after index cycling. This may take some load from Elasticsearch
@@ -393,14 +506,6 @@ disable_index_optimization = {{ graylog_disable_index_optimization }}
 # on heavily used systems with large indices, but it will decrease search performance. The default is 1.
 index_optimization_max_num_segments = {{ graylog_index_optimization_max_num_segments }}
 
-# Disable the index range calculation on all open/available indices and only calculate the range for the latest
-# index.
-# This may speed up index cycling on systems with large indices but it might lead to wrong search results
-# in regard to the time range of the messages (i. e. messages within a certain range may not be found) if the indices
-# have been modified after Graylog rotated them.
-# Default: true
-disable_index_range_calculation = {{ graylog_disable_index_range_calculation }}
-
 # The threshold of the garbage collection runs. If GC runs take longer than this threshold, a system notification
 # will be generated to warn the administrator about possible problems with the system. Default is 1 second.
 gc_warning_threshold = {{ graylog_gc_warning_threshold }}
@@ -408,17 +513,24 @@ gc_warning_threshold = {{ graylog_gc_warning_threshold }}
 # Connection timeout for a configured LDAP server (e. g. ActiveDirectory) in milliseconds.
 ldap_connection_timeout = {{ graylog_ldap_connection_timeout }}
 
-## Enable collection of Graylog-related metrics into MongoDB
-enable_metrics_collection = {{ graylog_enable_metrics_collection }}
-
 # Disable the use of SIGAR for collecting system stats
 disable_sigar = {{ graylog_disable_sigar }}
 
-# Amount of time of inactivity after which collectors are flagged as inactive (Default: 1 minute)
-collector_inactive_threshold = {{ graylog_collector_inactive_threshold }}
-
-# Amount of time after which inactive collectors are purged (Default: 14 days)
-collector_expiration_threshold = {{ graylog_collector_expiration_threshold }}
-
 # The default cache time for dashboard widgets. (Default: 10 seconds, minimum: 1 second)
 dashboard_widget_default_cache_time = {{ graylog_dashboard_widget_default_cache_time }}
+
+# Automatically load content packs in "content_packs_dir" on the first start of Graylog.
+content_packs_loader_enabled = {{ graylog_content_packs_loader_enabled }}
+
+# The directory which contains content packs which should be loaded on the first start of Graylog.
+content_packs_dir = {{ graylog_content_packs_dir }}
+
+# A comma-separated list of content packs (files in "content_packs_dir") which should be applied on
+# the first start of Graylog.
+# Default: empty
+content_packs_auto_load = {{ graylog_content_packs_auto_load }}
+
+# For some cluster-related REST requests, the node must query all other nodes in the cluster. This is the maximum number
+# of threads available for this. Increase it, if '/cluster/*' requests take long to complete.
+# Should be rest_thread_pool_size * average_cluster_size if you have a high number of concurrent users.
+proxied_requests_thread_pool_size = {{ graylog_proxied_requests_thread_pool_size }}

--- a/templates/graylog.server.elasticsearch.yml.j2
+++ b/templates/graylog.server.elasticsearch.yml.j2
@@ -1,5 +1,5 @@
 cluster.name: {{ graylog_elasticsearch_cluster_name }}
-node.name: {{ graylog_elasticsearch_node_name }}
+node.name: {{ graylog_elasticsearch_node_name_prefix }}{{ inventory_hostname }}
 node.master: false
 node.data: false
 transport.tcp.port: {{ graylog_elasticsearch_transport_tcp_port }}


### PR DESCRIPTION
I did the following:

* grabbed /etc/graylog/server/server.conf from the Debian package (version 2.1.1-2) and matched the _graylog.server.conf.j2_ to it.
* removed unused defaults and added the new ones.
* updated _graylog.server.elasticsearch.yml.j2_  since `graylog_elasticsearch_node_name` got replaced by `elasticsearch_node_name_prefix` (see http://docs.graylog.org/en/2.1/pages/upgrade/graylog-2.0.html).