### PR TITLE
Do not update cache when installing server

### DIFF
--- a/tasks/setup-Debian.yml
+++ b/tasks/setup-Debian.yml
@@ -67,4 +67,3 @@
   apt:
     name: 'graylog-server'
     state: present
-    update_cache: True


### PR DESCRIPTION
This prevents the Ansible _changed_ state of "Install Graylog server" task when nothing actually changed.

The cache is (forced) updated when a new repo is installed. The OS updates (should) the cache periodically.