### PR TITLE
Start server after installation

### DIFF
--- a/tasks/setup-Debian.yml
+++ b/tasks/setup-Debian.yml
@@ -67,3 +67,4 @@
   apt:
     name: 'graylog-server'
     state: present
+  notify: restart graylog-server

--- a/tasks/setup-RedHat.yml
+++ b/tasks/setup-RedHat.yml
@@ -9,3 +9,4 @@
   yum:
     name: 'graylog-server'
     state: present
+  notify: restart graylog-server


### PR DESCRIPTION
When the Debian (and Redhat?) package is installed the server is not started.

I triggered this during a test were I removed the package (`apt get remove graylog-server`), whle the configuration was still intact.

The package got installed properly, but the service was not started.