### PR TITLE
/etc/sysconfig/graylog-server should hold the startup parameters on RHEL

### DIFF
--- a/tasks/server.yml
+++ b/tasks/server.yml
@@ -15,9 +15,9 @@
     mode: '0644'
   notify: restart graylog-server
 
-- name: Configure Graylog server defaults
+- name: Graylog server defaults should be configured
   template:
-    src: graylog.server.default.j2
+    src: 'graylog.server.default.j2'
     dest: '/etc/default/graylog-server'
     owner: graylog
     group: graylog

--- a/tasks/server.yml
+++ b/tasks/server.yml
@@ -13,8 +13,13 @@
 
 - name: Configure Graylog server defaults
   template: src=graylog.server.default.j2 dest=/etc/default/graylog-server owner=graylog group=graylog mode=0644
+  when: ansible_os_family == 'Debian'
+  notify: restart graylog-server
+
+- name: Configure Graylog server sysconfig
+  template: src=graylog.server.default.j2 dest=/etc/sysconfig/graylog-server owner=graylog group=graylog mode=0644
+  when: ansible_os_family == 'RedHat'
   notify: restart graylog-server
 
 - name: Ensure Graylog server starts after reboot
   file: path=/etc/init/graylog-server.override state=absent
-

--- a/tests/support/centos7.Dockerfile
+++ b/tests/support/centos7.Dockerfile
@@ -22,7 +22,7 @@ RUN yum install -y ca-certificates-2015.2.6 \
                    git-1.8.3.1 \
                    openssl-1.0.1e \
                    openssl-devel-1.0.1e \
-                   python-pip-7.1.0 \
+                   python2-pip-8.1.2 \
                    python-devel-2.7.5 \
                    libffi-devel-3.0.13
 RUN pip install --upgrade pip setuptools


### PR DESCRIPTION
/etc/default/graylog-server and /etc/sysconfig/graylog-server serve the same purpose. On Centos7 the first is not read during startup, so I added an action for ansible_os_family == 'RedHat'. The other action for /etc/default is now scoped to ansible_os_family == 'Debian'.