### PR TITLE
Get graylog2 and dependencies working properly and well documented

### DIFF
--- a/README.md
+++ b/README.md
@@ -160,13 +160,12 @@ Example:
 - name: Install java from openjdk
   hosts: graylog2_servers
   become: yes
-    
+  vars:
+    # --- ommited lines ---
+    graylog_install_java: false    
   roles:    
     
     - role: geerlingguy.java
-      vars:
-        # --- ommited lines ---
-        graylog_install_java: false
       
       when: ansible_distribution_release == 'trusty'
       java_packages:

--- a/README.md
+++ b/README.md
@@ -226,7 +226,7 @@ Example:
       
       when: ansible_distribution_release == 'trusty'
       java_packages:
-        - openjdk-8-jdk   # This is the same package that elasticsearch installs
+        - openjdk-8-jdk  
     
     - role: 'Graylog2.graylog-ansible-role'
       tags: graylog

--- a/README.md
+++ b/README.md
@@ -242,10 +242,15 @@ Is good to be explicit, these are all the roles that you need to run for graylog
 If not set in this will it will work anyway, but you don't see the roles until you run it. 
 Note: in this example vars are in a more appropiate place at `group_vars/group/vars` 
 
-```
+```yaml
 - name: Apply roles for graylog2 servers
   hosts: graylog2_servers
   become: yes
+  vars:
+    graylog_install_elasticsearch: False
+    graylog_install_mongodb:       False
+    graylog_install_nginx:         False
+    graylog_install_java:          False
 
   roles:
 
@@ -279,6 +284,7 @@ Note: in this example vars are in a more appropiate place at `group_vars/group/v
         - graylog2_servers
 
 ```
+
 
 
 Conditional role dependencies

--- a/README.md
+++ b/README.md
@@ -346,3 +346,4 @@ License
 Author: Marius Sturm (<marius@graylog.com>) and [contributors](https://github.com/Graylog2/graylog2-ansible-role/graphs/contributors)
 
 License: Apache 2.0
+

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -1,6 +1,5 @@
 ---
 # Requirements
-graylog_install_java:              true
 graylog_java_ppa:                  'ppa:webupd8team/java'
 graylog_java_repo:                 'deb http://ppa.launchpad.net/webupd8team/java/ubuntu trusty main'
 graylog_java_src_repo:             'deb-src http://ppa.launchpad.net/webupd8team/java/ubuntu trusty main'
@@ -168,3 +167,4 @@ graylog_server_wrapper:       ''
 graylog_install_elasticsearch: True
 graylog_install_mongodb:       True
 graylog_install_nginx:         True
+graylog_install_java:          True

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -1,5 +1,6 @@
 ---
 # Requirements
+graylog_install_java:              true
 graylog_java_ppa:                  'ppa:webupd8team/java'
 graylog_java_repo:                 'deb http://ppa.launchpad.net/webupd8team/java/ubuntu trusty main'
 graylog_java_src_repo:             'deb-src http://ppa.launchpad.net/webupd8team/java/ubuntu trusty main'

--- a/meta/main.yml
+++ b/meta/main.yml
@@ -1,5 +1,6 @@
 ---
 dependencies:
+
   - role: 'lesmyrmidons.mongodb'
     when: graylog_install_mongodb
 

--- a/tasks/setup-Debian.yml
+++ b/tasks/setup-Debian.yml
@@ -9,7 +9,7 @@
     repo: "{{ graylog_java_ppa }}"
     state: present
     update_cache: True
-  when: ansible_distribution == 'Ubuntu'
+  when: ansible_distribution == 'Ubuntu' and graylog_install_java
 
 - block:
     - name: 'Repositories should be updated (Debian)'
@@ -26,7 +26,7 @@
         keyserver: "{{ graylog_java_repo_keyserver }}"
         id: "{{ graylog_java_repo_key }}"
 
-  when: ansible_distribution == 'Debian'
+  when: ansible_distribution == 'Debian' and graylog_install_java
 
 - name: Oracle license should be accepted
   debconf:
@@ -34,12 +34,14 @@
     question: "shared/{{ graylog_java_oracle_license_key }}"
     value: 'true'
     vtype: 'select'
+  when: graylog_install_java
 
 - name: Java 8 should be installed
   apt:
     name: 'oracle-java8-installer'
     state: present
     force: True
+  when: graylog_install_java
 
 - name: Graylog repository package should be downloaded
   get_url:


### PR DESCRIPTION
Hello, 

I have been working to setup graylog2 properly and find that there was some missing and important notes in the README, also I have added an option to install java from openjdk and not from oracle (keeping the default behaviour as it was in the role, then documented on the README too). 

Resume: 

* Added graylog_install_java var
* Added README example to install openjdk instead of Oracle java

* fix issues with ansible 2.2 (Added examples on the README)
* fix issues with elasticsearch version, explicit set the es version and java version (Documented missing information in the README about graylog incompatibility with elasticsearch 5.x)
* fix issues with java version from elasticsearch role (Documented on README)
* added more useful vars when you are explicit with the usage of roles. (On README)
* fix wrong example for var web_endpoint_uri  on README. (missing information about how webclient works)
