### PR TITLE
Variablize trusted_proxies in graylog.server.conf

### DIFF
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -142,6 +142,7 @@ graylog_transport_email_web_interface_url: ''
 # Proxy
 graylog_http_proxy_uri:                    ''
 graylog_proxied_requests_thread_pool_size: 32
+graylog_trusted_proxies:                   ''
 
 # Web UI
 graylog_web_enable:                  'True'

--- a/templates/graylog.server.conf.j2
+++ b/templates/graylog.server.conf.j2
@@ -127,7 +127,11 @@ rest_thread_pool_size = {{ graylog_rest_thread_pool_size }}
 
 # Comma separated list of trusted proxies that are allowed to set the client address with X-Forwarded-For
 # header. May be subnets, or hosts.
+{% if graylog_trusted_proxies %}
+trusted_proxies = {{ graylog_trusted_proxies }}
+{% else %}
 #trusted_proxies = 127.0.0.1/32, 0:0:0:0:0:0:0:1/128
+{% endif %}
 
 # Enable the embedded Graylog web interface.
 # Default: true


### PR DESCRIPTION
Allow changing `trusted_proxies` in server.conf using new variable `graylog_trusted_proxies` which defaults to empty (leaving the line commented in config). Tested with Ansible 2.2.