### PR TITLE
Update requirements for Ansible 2.2

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,18 +3,32 @@ services:
   - docker
 
 install:
-  - docker build -t graylog-ansible-role-wheezy  -f tests/support/wheezy.Dockerfile  tests/support
-  - docker build -t graylog-ansible-role-trusty  -f tests/support/trusty.Dockerfile  tests/support
-  - docker build -t graylog-ansible-role-centos7 -f tests/support/centos7.Dockerfile tests/support
-  - docker build -t graylog-ansible-role-xenial  -f tests/support/xenial.Dockerfile  tests/support
-  - docker run -it -v $PWD:/role graylog-ansible-role-wheezy
-  - docker run -it -v $PWD:/role graylog-ansible-role-trusty
-  - docker run -it -v $PWD:/role:ro -v /sys/fs/cgroup:/sys/fs/cgroup:ro -d --privileged graylog-ansible-role-centos7 /usr/sbin/init
-  - DOCKER_CONTAINER_ID=$(docker ps | grep centos | awk '{print $1}')
+  - docker build -t graylog-ansible-role-wheezy-21  -f tests/support/wheezy_21.Dockerfile  tests/support
+  - docker build -t graylog-ansible-role-trusty-21  -f tests/support/trusty_21.Dockerfile  tests/support
+  - docker build -t graylog-ansible-role-centos7-21 -f tests/support/centos7_21.Dockerfile tests/support
+  - docker build -t graylog-ansible-role-xenial-21  -f tests/support/xenial_21.Dockerfile  tests/support
+  - docker build -t graylog-ansible-role-wheezy-22  -f tests/support/wheezy_22.Dockerfile  tests/support
+  - docker build -t graylog-ansible-role-trusty-22  -f tests/support/trusty_22.Dockerfile  tests/support
+  - docker build -t graylog-ansible-role-centos7-22 -f tests/support/centos7_22.Dockerfile tests/support
+  - docker build -t graylog-ansible-role-xenial-22  -f tests/support/xenial_22.Dockerfile  tests/support
+  - docker run -it -v $PWD:/role graylog-ansible-role-wheezy-21
+  - docker run -it -v $PWD:/role graylog-ansible-role-wheezy-22
+  - docker run -it -v $PWD:/role graylog-ansible-role-trusty-21
+  - docker run -it -v $PWD:/role graylog-ansible-role-trusty-22
+  - docker run -it -v $PWD:/role:ro -v /sys/fs/cgroup:/sys/fs/cgroup:ro -d --privileged graylog-ansible-role-centos7-21 /usr/sbin/init
+  - DOCKER_CONTAINER_ID=$(docker ps | grep centos7-21 | awk '{print $1}')
   - docker logs $DOCKER_CONTAINER_ID
   - docker exec -it $DOCKER_CONTAINER_ID /bin/bash -xec "bash -x run-tests.sh"
-  - docker run -it -v $PWD:/role:ro -v /sys/fs/cgroup:/sys/fs/cgroup:ro -d --privileged graylog-ansible-role-xenial /sbin/init
-  - DOCKER_CONTAINER_ID=$(docker ps | grep xenial | awk '{print $1}')
+  - docker run -it -v $PWD:/role:ro -v /sys/fs/cgroup:/sys/fs/cgroup:ro -d --privileged graylog-ansible-role-centos7-22 /usr/sbin/init
+  - DOCKER_CONTAINER_ID=$(docker ps | grep centos7-22 | awk '{print $1}')
+  - docker logs $DOCKER_CONTAINER_ID
+  - docker exec -it $DOCKER_CONTAINER_ID /bin/bash -xec "bash -x run-tests.sh"
+  - docker run -it -v $PWD:/role:ro -v /sys/fs/cgroup:/sys/fs/cgroup:ro -d --privileged graylog-ansible-role-xenial-21 /sbin/init
+  - DOCKER_CONTAINER_ID=$(docker ps | grep xenial-21 | awk '{print $1}')
+  - docker logs $DOCKER_CONTAINER_ID
+  - docker exec -it $DOCKER_CONTAINER_ID /bin/bash -xec "bash -x run-tests.sh"
+  - docker run -it -v $PWD:/role:ro -v /sys/fs/cgroup:/sys/fs/cgroup:ro -d --privileged graylog-ansible-role-xenial-22 /sbin/init
+  - DOCKER_CONTAINER_ID=$(docker ps | grep xenial-22 | awk '{print $1}')
   - docker logs $DOCKER_CONTAINER_ID
   - docker exec -it $DOCKER_CONTAINER_ID /bin/bash -xec "bash -x run-tests.sh"
 

--- a/README.md
+++ b/README.md
@@ -8,36 +8,13 @@ Ansible role which installs and configures Graylog log management.
 Dependencies
 ------------
 
-- Ansible 2.0 or higher.
+- **Ansible versions > 2.1.2 or > 2.2.1 are supported.**
 - [MongoDB](https://github.com/lesmyrmidons/ansible-role-mongodb) (use master version for compatibility with Ansible 2.2 see [issue#5](https://github.com/lesmyrmidons/ansible-role-mongodb/issues/5))
-- [Elasticsearch](https://github.com/elastic/ansible-elasticsearch) (Use 0.2 version to ensure compatibility with 2.x)
+- [Elasticsearch](https://github.com/elastic/ansible-elasticsearch) (Use 0.2 version to ensure compatibility with 2.x. Graylog doesn't support Elasticsearch 5.x yet)
 - [Nginx](https://github.com/jdauphant/ansible-role-nginx)
 - Tested on Ubuntu 14.04, 16.04 / Debian 7 / Centos 7
 
-Example for `requirements.yml` file comptabile with ansible 2.2:
-
-```
-# graylog2 
-
-- src: graylog2.graylog
-  version: master
-
-# graylog2 dependency
-
-- src: lesmyrmidons.mongodb
-  version: master
-
-- src: geerlingguy.java
-  version: master
-
-# 0.2 is required version to use elasticsearch 2.x
-- src: elastic.elasticsearch
-  version: "0.2"
-
-- src: jdauphant.nginx
-  version: master
-
-```
+See the `requirements.yml` file for a comptabile configuration for Ansible 2.1 and 2.2.
 
 Quickstart
 ----------

--- a/requirements.yml
+++ b/requirements.yml
@@ -1,7 +1,7 @@
 ---
 - name: 'lesmyrmidons.mongodb'
   src: 'https://github.com/lesmyrmidons/ansible-role-mongodb.git'
-  version: 'v1.1.0'
+  version: 'master'
 
 - name: 'elastic.elasticsearch'
   src: 'https://github.com/elastic/ansible-elasticsearch.git'
@@ -9,4 +9,4 @@
 
 - name: 'jdauphant.nginx'
   src: 'https://github.com/jdauphant/ansible-role-nginx.git'
-  version: 'v2.3.1'
+  version: 'v2.7.4'

--- a/tests/graylog.yml
+++ b/tests/graylog.yml
@@ -3,6 +3,11 @@
   hosts: localhost
   connection: local
   vars:
+    graylog_install_elasticsearch: False
+    graylog_install_mongodb:       False
+    graylog_install_nginx:         False
+    graylog_install_java:          False
+
     es_instance_name: 'graylog'
     es_scripts: False
     es_templates: False

--- a/tests/support/centos7_21.Dockerfile
+++ b/tests/support/centos7_21.Dockerfile
@@ -1,0 +1,31 @@
+FROM centos:7
+
+ENV container docker
+
+RUN (cd /lib/systemd/system/sysinit.target.wants/; for i in *; do [ $i == systemd-tmpfiles-setup.service ] || rm -f $i; done); \
+    rm -f /lib/systemd/system/multi-user.target.wants/*;\
+    rm -f /etc/systemd/system/*.wants/*;\
+    rm -f /lib/systemd/system/local-fs.target.wants/*; \
+    rm -f /lib/systemd/system/sockets.target.wants/*udev*; \
+    rm -f /lib/systemd/system/sockets.target.wants/*initctl*; \
+    rm -f /lib/systemd/system/basic.target.wants/*;\
+    rm -f /lib/systemd/system/anaconda.target.wants/*;
+
+VOLUME [ "/sys/fs/cgroup" ]
+
+RUN echo 'root:root' | chpasswd
+
+RUN yum update -y && \
+    yum install -y epel-release
+RUN yum install -y ca-certificates \
+                   gcc \
+                   git \
+                   openssl \
+                   openssl-devel \
+                   python2-pip \
+                   python-devel \
+                   libffi-devel
+RUN pip install setuptools
+RUN pip install ansible==2.1.2
+
+COPY run-tests.sh run-tests.sh

--- a/tests/support/centos7_22.Dockerfile
+++ b/tests/support/centos7_22.Dockerfile
@@ -26,6 +26,6 @@ RUN yum install -y ca-certificates \
                    python-devel \
                    libffi-devel
 RUN pip install setuptools
-RUN pip install ansible==2.1
+RUN pip install ansible==2.2.1
 
 COPY run-tests.sh run-tests.sh

--- a/tests/support/trusty_21.Dockerfile
+++ b/tests/support/trusty_21.Dockerfile
@@ -1,0 +1,17 @@
+FROM ubuntu:trusty
+
+RUN apt-get -y update
+RUN apt-get -y install ca-certificates \
+                       git \
+                       gcc \
+                       openssh-client \
+                       openssl \
+                       python-pip \
+                       python-dev \
+                       libffi-dev \
+                       libssl-dev
+RUN pip install setuptools \
+                ansible==2.1.2
+
+COPY run-tests.sh run-tests.sh
+CMD ["./run-tests.sh"]

--- a/tests/support/trusty_22.Dockerfile
+++ b/tests/support/trusty_22.Dockerfile
@@ -1,13 +1,17 @@
-FROM debian:wheezy
+FROM ubuntu:trusty
 
 RUN apt-get -y update
 RUN apt-get -y install ca-certificates \
                        git \
+                       gcc \
                        openssh-client \
+                       openssl \
                        python-pip \
                        python-dev \
-                       libffi-dev
-RUN pip install ansible==2.1
+                       libffi-dev \
+                       libssl-dev
+RUN pip install setuptools \
+                ansible==2.2.1
 
 COPY run-tests.sh run-tests.sh
 CMD ["./run-tests.sh"]

--- a/tests/support/wheezy_21.Dockerfile
+++ b/tests/support/wheezy_21.Dockerfile
@@ -1,0 +1,13 @@
+FROM debian:wheezy
+
+RUN apt-get -y update
+RUN apt-get -y install ca-certificates \
+                       git \
+                       openssh-client \
+                       python-pip \
+                       python-dev \
+                       libffi-dev
+RUN pip install ansible==2.1.2
+
+COPY run-tests.sh run-tests.sh
+CMD ["./run-tests.sh"]

--- a/tests/support/wheezy_22.Dockerfile
+++ b/tests/support/wheezy_22.Dockerfile
@@ -1,0 +1,13 @@
+FROM debian:wheezy
+
+RUN apt-get -y update
+RUN apt-get -y install ca-certificates \
+                       git \
+                       openssh-client \
+                       python-pip \
+                       python-dev \
+                       libffi-dev
+RUN pip install ansible==2.2.1
+
+COPY run-tests.sh run-tests.sh
+CMD ["./run-tests.sh"]

--- a/tests/support/xenial_21.Dockerfile
+++ b/tests/support/xenial_21.Dockerfile
@@ -1,4 +1,10 @@
-FROM ubuntu:trusty
+FROM ubuntu:xenial
+
+ENV container docker
+
+VOLUME [ "/sys/fs/cgroup" ]
+
+RUN echo 'root:root' | chpasswd
 
 RUN apt-get -y update
 RUN apt-get -y install ca-certificates \
@@ -11,7 +17,7 @@ RUN apt-get -y install ca-certificates \
                        libffi-dev \
                        libssl-dev
 RUN pip install setuptools \
-                ansible==2.1
+                ansible==2.1.2
 
 COPY run-tests.sh run-tests.sh
 CMD ["./run-tests.sh"]

--- a/tests/support/xenial_22.Dockerfile
+++ b/tests/support/xenial_22.Dockerfile
@@ -17,7 +17,7 @@ RUN apt-get -y install ca-certificates \
                        libffi-dev \
                        libssl-dev
 RUN pip install setuptools \
-                ansible==2.1
+                ansible==2.2.1
 
 COPY run-tests.sh run-tests.sh
 CMD ["./run-tests.sh"]


### PR DESCRIPTION
Ansible 2.2 should be the main target version of this role. This PR:

  * Updates the dependencies to work with 2.2
  * Separates the test suite into 2.1 and 2.2 tests to simplify debugging of version issues
  * Limit the test suite to only test this role for idempotency (we can not garanty the same for dependencies)
  * Mark 2.2.1 and 2.1.2 as supported versions in the README 