### PR TITLE
Fix server package version

### DIFF
--- a/tasks/setup-Debian.yml
+++ b/tasks/setup-Debian.yml
@@ -67,6 +67,6 @@
 
 - name: Graylog server package should be installed
   apt:
-    name: "graylog-server{{ graylog_server_version is defined | ternary('=' + graylog_version, '') }}"
+    name: "graylog-server{% if graylog_server_version is defined %}={{ graylog_server_version }}{% endif %}"
     state: present
   notify: restart graylog-server

--- a/tasks/setup-RedHat.yml
+++ b/tasks/setup-RedHat.yml
@@ -7,6 +7,6 @@
 
 - name: Graylog server should be installed
   yum:
-    name: "graylog-server{{ graylog_server_version is defined | ternary('-' + graylog_version, '') }}"
+    name: "graylog-server{% if graylog_server_version is defined %}-{{ graylog_server_version }}{% endif %}"
     state: present
   notify: restart graylog-server


### PR DESCRIPTION
When you force the server's package version, the playbook tests if the `graylog_server_version` variable is defined but the `graylog_version` is used.

Here is a small fix for this.

Tested on graylog-server 2.2.2-1 on Ubuntu.