### PR TITLE
added Pin priority for elasticsearch to 2.* to avoid upgrades to 5.x version of elasticsearch

### DIFF
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -10,6 +10,8 @@ graylog_apt_deb_url:               "https://packages.graylog2.org/repo/packages/
 graylog_yum_rpm_url:               "https://packages.graylog2.org/repo/packages/graylog-{{ graylog_version }}-repository_latest.rpm"
 graylog_java_oracle_installer_key: 'oracle-java8-installer'
 graylog_java_oracle_license_key:   'accepted-oracle-license-v1-1'
+# This will ensure to have es version 2.x, even when for some reason es repo 5.x is added (ex when logstash 5.x is installed)
+graylog_es_debian_pin_version:     '2.*'
 
 # General
 graylog_is_master:            'True'

--- a/tasks/setup-Debian.yml
+++ b/tasks/setup-Debian.yml
@@ -73,3 +73,11 @@
     name: "graylog-server{% if graylog_server_version is defined %}={{ graylog_server_version }}{% endif %}"
     state: present
   notify: restart graylog-server
+
+# This will ensure to have es version 2.x, even when for some reason es repo 5.x is added (ex when logstash 5.x is installed)
+- name: setup-Debian.yml | Set elasticsearch priority to {{ graylog_es_debian_pin_version }} apt_preferences
+  template:
+    src: 'apt_preferences.d/debian_elasticsearch.j2'
+    dest: '/etc/apt/preferences.d/elasticsearch'
+    owner: root
+    mode: '0644'

--- a/templates/apt_preferences.d/debian_elasticsearch.j2
+++ b/templates/apt_preferences.d/debian_elasticsearch.j2
@@ -1,0 +1,3 @@
+Package: elasticsearch
+Pin: version {{ graylog_es_debian_pin_version }}
+Pin-Priority: 1001


### PR DESCRIPTION
This will ensure elasticsearch will not upgrade even when some other role (like logstash) added 5.x repository of elasticsearch. 
It's possible in this way to safetly install logstash with graylog to add more inputs to graylog. 