### PR TITLE
Remove useless package

### DIFF
--- a/tasks/setup-Debian.yml
+++ b/tasks/setup-Debian.yml
@@ -1,9 +1,4 @@
 ---
-- name: 'Package "python-software-properties" should be installed'
-  apt:
-    name: 'python-software-properties'
-    state: present
-
 - name: Graylog repository package should be downloaded
   get_url:
     url: "{{ graylog_apt_deb_url }}"


### PR DESCRIPTION
`add-apt-repository`, provided by python-software-properties for Debian < 9 and by software-properties-common on Debian 9, is not used anywhere.

This task was useless and made the role incompatible with Debian 9.