### PR TITLE
Adds a switch to enable/disable repository management

### DIFF
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -7,7 +7,9 @@ graylog_java_repo_keyserver:       'keyserver.ubuntu.com'
 graylog_java_repo_key:             'EEA14886'
 graylog_version:                   '2.3'
 graylog_apt_deb_url:               "https://packages.graylog2.org/repo/packages/graylog-{{ graylog_version }}-repository_latest.deb"
+graylog_manage_apt_repo:           'True'
 graylog_yum_rpm_url:               "https://packages.graylog2.org/repo/packages/graylog-{{ graylog_version }}-repository_latest.rpm"
+graylog_manage_yum_repo:           'True'
 graylog_java_oracle_installer_key: 'oracle-java8-installer'
 graylog_java_oracle_license_key:   'accepted-oracle-license-v1-1'
 # This will ensure to have es version 2.x, even when for some reason es repo 5.x is added (ex when logstash 5.x is installed)

--- a/tasks/setup-Debian.yml
+++ b/tasks/setup-Debian.yml
@@ -3,6 +3,7 @@
   get_url:
     url: "{{ graylog_apt_deb_url }}"
     dest: '/tmp/graylog_repository.deb'
+  when: graylog_manage_apt_repo
 
 - name: 'Package "apt-transport-https" should be installed'
   apt:
@@ -14,6 +15,7 @@
     deb: '/tmp/graylog_repository.deb'
     state: installed
     dpkg_options: 'force-all'
+  when: graylog_manage_apt_repo
   register: install_repo
 
 - name: APT cache should be updated

--- a/tasks/setup-RedHat.yml
+++ b/tasks/setup-RedHat.yml
@@ -4,6 +4,7 @@
     name: "{{ graylog_yum_rpm_url }}"
     state: present
     update_cache: True
+  when: graylog_manage_yum_repo
 
 - name: Graylog server should be installed
   yum:


### PR DESCRIPTION
In some environments you can't access external repositories, so you have to use a local mirror instead. This adds the possibility to not use the default rpm/deb repo and manage it externally, by setting graylog_manage_(yum|apt)_repo to False.