### PR TITLE
add selinux mongodb port

### DIFF
--- a/tasks/mongodb-RedHat.yml
+++ b/tasks/mongodb-RedHat.yml
@@ -25,6 +25,14 @@
     group: root
     mode: '0644'
   notify: restart mongod
+  
+# Allow MongoDB to listen on tcp port 27017
+- name: set SELinux MongoDB Port access allowed
+  seport:
+    ports: 27017
+    proto: tcp
+    setype: mongod_port_t
+    state: present
 
 - meta: flush_handlers
 - name: Wait for MongoDB to startup


### PR DESCRIPTION
tested the above on RHEL 6.9 and CentOS 7 - on both SELinux runs on default. 

Ansible might complain about a missing package ( `yum install policycoreutils-python` ) but I did not include automatic install of that - as even elastic did not have that for the selinux parts.

```
ansible 2.4.2.0
  config file = /etc/ansible/ansible.cfg
  configured module search path = [u'/root/.ansible/plugins/modules', u'/usr/share/ansible/plugins/modules']
  ansible python module location = /usr/lib/python2.6/site-packages/ansible
  executable location = /usr/bin/ansible
  python version = 2.6.6 (r266:84292, Aug  9 2016, 06:11:56) [GCC 4.4.7 20120313 (Red Hat 4.4.7-17)
```