### PR TITLE
Fix startup timeout (unexpected sig 15) for MongoDB service/process m…

### DIFF
--- a/templates/mongodb.conf.j2
+++ b/templates/mongodb.conf.j2
@@ -25,7 +25,8 @@ net:
   bindIp: 127.0.0.1
 
 
-#processManagement:
+processManagement:
+  fork: false
 
 #security:
 

--- a/templates/mongodb.service.j2
+++ b/templates/mongodb.service.j2
@@ -4,6 +4,7 @@ After=network.target
 Documentation=https://docs.mongodb.org/manual
 
 [Service]
+Type=oneshot
 User=mongodb
 Group=mongodb
 ExecStart=/usr/bin/mongod --quiet --config /etc/mongod.conf


### PR DESCRIPTION
Issue and solution: https://serverfault.com/a/867472

More explanation here: https://askubuntu.com/a/787431 (quotation below)

"... mongod is completely unnecessarily forking. Because it is forking, systemd is thinking that the main dæmon process has exited unexpectedly, and it is cleaning up the service back to its stopped state. It does this by explicitly terminating all of the child processes left around by the service. Hence the signal.

This is a readiness protocol mismatch. MongoDB does not speak the forking readiness protocol, and it is not correct to change the systemd service unit to say that it does. It is, rather, correct to change the configuration of MongoDB so that it does not completely unnecessarily fork."