### PR TITLE
variablized graylog install state to support upgrades

### DIFF
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -7,6 +7,7 @@ graylog_java_src_repo:             "deb-src http://ppa.launchpad.net/webupd8team
 graylog_java_repo_keyserver:       "keyserver.ubuntu.com"
 graylog_java_repo_key:             "EEA14886"
 graylog_version:                   "2.4"
+graylog_package_state:             "present"
 graylog_apt_deb_url:               "https://packages.graylog2.org/repo/packages/graylog-{{ graylog_version }}-repository_latest.deb"
 graylog_manage_apt_repo:           True
 graylog_yum_rpm_url:               "https://packages.graylog2.org/repo/packages/graylog-{{ graylog_version }}-repository_latest.rpm"

--- a/tasks/setup-Debian.yml
+++ b/tasks/setup-Debian.yml
@@ -27,7 +27,7 @@
 - name: "Graylog server package should be installed"
   apt:
     name: "graylog-server{% if graylog_server_version is defined %}={{ graylog_server_version }}{% endif %}"
-    state: "present"
+    state: "{{ graylog_package_state }}"
   notify: "restart graylog-server"
 
 - name: "setup-Debian.yml | Set elasticsearch priority to {{ graylog_es_debian_pin_version }} apt_preferences"

--- a/tasks/setup-RedHat.yml
+++ b/tasks/setup-RedHat.yml
@@ -10,5 +10,5 @@
 - name: "Graylog server should be installed"
   yum:
     name: "graylog-server{% if graylog_server_version is defined %}-{{ graylog_server_version }}{% endif %}"
-    state: "present"
+    state: "{{ graylog_package_state }}"
   notify: restart graylog-server


### PR DESCRIPTION
Variablized graylog install state instead of hard coding `present` to support users who need/want to upgrade their graylog versions.  