### PR TITLE
Modified the example playbook in the README to fix ES startup errors

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,7 +39,7 @@ Quickstart
       http.port: 9200
       transport.tcp.port: 9300
       network.host: "0.0.0.0"
-      node.data: True,
+      node.data: True
       node.master: True
 
     # Elasticsearch role already installed Java


### PR DESCRIPTION
Hey thanks for the Ansible playbook here.  When attempting to execute the example provided on the README page it seems there is an unnecessary comma within the YAML playbook syntax.

This comma ends up getting inserted into an Elasticsearch configuration file, and in turn causes Elasticsearch to choke when starting up with an error like below:

> java.lang.IllegalArgumentException: Failed to parse value [True,] cannot be parsed to boolean [ true/1/on/yes OR false/0/off/no ]

You'll know you're having the issue when you execute the sample playbook and it will hang on the task for:

> TASK [elastic.elasticsearch : Wait for elasticsearch to startup]

Removing the comma from the playbook seemed to resolve the issue for me. Hope this helps someone else.