### PR TITLE
Testing should be made dynamic

### DIFF
--- a/tasks/server.yml
+++ b/tasks/server.yml
@@ -33,9 +33,12 @@
 - meta: "flush_handlers"
 
 - name: "Wait for Graylog server to startup"
-  wait_for:
-    host: "127.0.0.1"
-    port: 9000
-    delay: 5
-    connect_timeout: 1
+  uri:
+    url: "{{ graylog_web_listen_uri }}"
+    status_code: 200
+    validate_certs: False
+  register: result
+  until: result.status == 200
+  retries: 60
+  delay: 5
   when: graylog_not_testing


### PR DESCRIPTION
The task _Wait for Graylog server to startup_ should be more dynamic and allow for testing URI other than localhost. This PR enables waiting for the `graylog_web_listen_uri` to become active.