### PR TITLE
allow to use the same role to install graylog version < 2.4

### DIFF
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -57,8 +57,27 @@ graylog_elasticsearch_http_enabled:                     False
 graylog_disable_index_optimization:                     True
 graylog_index_optimization_max_num_segments:            1
 
+# Graylog version < 2.4
+graylog_elasticsearch_node_name_prefix:                 'graylog-'
+graylog_elasticsearch_shards:                           4
+graylog_elasticsearch_replicas:                         0
+graylog_elasticsearch_cluster_name:                     'graylog'
+graylog_elasticsearch_transport_tcp_port:               9350
+graylog_elasticsearch_discovery_zen_ping_unicast_hosts: '127.0.0.1:9300'
+graylog_elasticsearch_network_host:                     ''
+graylog_elasticsearch_network_bind_host:                ''
+graylog_elasticsearch_network_publish_host:             ''
+
 # Retention
 graylog_no_retention:                        False
+
+# Graylog version < 2.4
+graylog_elasticsearch_retention_strategy:    'delete'
+graylog_rotation_strategy:                   'count'
+graylog_elasticsearch_max_docs_per_index:    20000000
+graylog_elasticsearch_max_number_of_indices: 20
+graylog_elasticsearch_max_size_per_index:    1073741824
+graylog_elasticsearch_max_time_per_index:    '1d'
 
 # Processing
 graylog_processbuffer_processors:         5

--- a/templates/graylog.server.conf.j2
+++ b/templates/graylog.server.conf.j2
@@ -211,6 +211,122 @@ allow_highlighting = {{ graylog_allow_highlighting }}
 # Default: http://127.0.0.1:9200
 elasticsearch_hosts = {{ graylog_elasticsearch_hosts }}
 
+{% if graylog_version < 2.4 %}
+# Graylog will use multiple indices to store documents in. You can configured the strategy it uses to determine
+# when to rotate the currently active write index.
+# It supports multiple rotation strategies:
+#   - "count" of messages per index, use elasticsearch_max_docs_per_index below to configure
+#   - "size" per index, use elasticsearch_max_size_per_index below to configure
+# valid values are "count", "size" and "time", default is "count"
+#
+# ATTENTION: These settings have been moved to the database in 2.0. When you upgrade, make sure to set these
+#            to your previous 1.x settings so they will be migrated to the database!
+rotation_strategy = {{ graylog_rotation_strategy }}
+
+# (Approximate) maximum number of documents in an Elasticsearch index before a new index
+# is being created, also see no_retention and elasticsearch_max_number_of_indices.
+# Configure this if you used 'rotation_strategy = count' above.
+#
+# ATTENTION: These settings have been moved to the database in 2.0. When you upgrade, make sure to set these
+#            to your previous 1.x settings so they will be migrated to the database!
+elasticsearch_max_docs_per_index = {{ graylog_elasticsearch_max_docs_per_index }}
+
+# (Approximate) maximum size in bytes per Elasticsearch index on disk before a new index is being created, also see
+# no_retention and elasticsearch_max_number_of_indices. Default is 1GB.
+# Configure this if you used 'rotation_strategy = size' above.
+#
+# ATTENTION: These settings have been moved to the database in 2.0. When you upgrade, make sure to set these
+#            to your previous 1.x settings so they will be migrated to the database!
+elasticsearch_max_size_per_index = {{ graylog_elasticsearch_max_size_per_index }}
+
+# (Approximate) maximum time before a new Elasticsearch index is being created, also see
+# no_retention and elasticsearch_max_number_of_indices. Default is 1 day.
+# Configure this if you used 'rotation_strategy = time' above.
+# Please note that this rotation period does not look at the time specified in the received messages, but is
+# using the real clock value to decide when to rotate the index!
+# Specify the time using a duration and a suffix indicating which unit you want:
+#  1w  = 1 week
+#  1d  = 1 day
+#  12h = 12 hours
+# Permitted suffixes are: d for day, h for hour, m for minute, s for second.
+#
+# ATTENTION: These settings have been moved to the database in 2.0. When you upgrade, make sure to set these
+#            to your previous 1.x settings so they will be migrated to the database!
+elasticsearch_max_time_per_index = {{ graylog_elasticsearch_max_time_per_index }}
+
+# How many indices do you want to keep?
+#
+# ATTENTION: These settings have been moved to the database in 2.0. When you upgrade, make sure to set these
+#            to your previous 1.x settings so they will be migrated to the database!
+elasticsearch_max_number_of_indices = {{ graylog_elasticsearch_max_number_of_indices }}
+
+# Decide what happens with the oldest indices when the maximum number of indices is reached.
+# The following strategies are availble:
+#   - delete # Deletes the index completely (Default)
+#   - close # Closes the index and hides it from the system. Can be re-opened later.
+#
+# ATTENTION: These settings have been moved to the database in 2.0. When you upgrade, make sure to set these
+#            to your previous 1.x settings so they will be migrated to the database!
+retention_strategy = {{ graylog_elasticsearch_retention_strategy }}
+
+# How many Elasticsearch shards and replicas should be used per index? Note that this only applies to newly created indices.
+elasticsearch_shards = {{ graylog_elasticsearch_shards }}
+elasticsearch_replicas = {{ graylog_elasticsearch_replicas }}
+
+# Prefix for all Elasticsearch indices and index aliases managed by Graylog.
+elasticsearch_index_prefix = {{ graylog_elasticsearch_index_prefix }}
+
+# Name of the Elasticsearch index template used by Graylog to apply the mandatory index mapping.
+# # Default: graylog-internal
+elasticsearch_template_name = {{ graylog_elasticsearch_template_name }}
+
+# settings to be passed to elasticsearch's client (overriding those in the provided elasticsearch_config_file)
+# all these
+# this must be the same as for your Elasticsearch cluster
+elasticsearch_cluster_name = {{ graylog_elasticsearch_cluster_name }}
+
+# The prefix being used to generate the Elasticsearch node name which makes it easier to identify the specific Graylog
+# server running the embedded Elasticsearch instance. The node name will be constructed by concatenating this prefix
+# and the Graylog node ID (see node_id_file), for example "graylog-17052010-1234-5678-abcd-1337cafebabe".
+# Default: graylog-
+elasticsearch_node_name_prefix = {{ graylog_elasticsearch_node_name_prefix }}
+
+# A comma-separated list of Elasticsearch nodes which Graylog is using to connect to the Elasticsearch cluster,
+# see https://www.elastic.co/guide/en/elasticsearch/reference/2.3/modules-discovery-zen.html for details.
+# Default: 127.0.0.1
+elasticsearch_discovery_zen_ping_unicast_hosts = {{ graylog_elasticsearch_discovery_zen_ping_unicast_hosts }}
+
+# Use multiple Elasticsearch nodes as seed
+#elasticsearch_discovery_zen_ping_unicast_hosts = 198.51.100.23:9300, 198.51.100.42:9300
+
+# we don't want the Graylog server to store any data, or be master node
+elasticsearch_node_master = false
+elasticsearch_node_data = false
+
+# use a different port if you run multiple Elasticsearch nodes on one machine
+elasticsearch_transport_tcp_port = {{ graylog_elasticsearch_transport_tcp_port }}
+
+# we don't need to run the embedded HTTP server here
+elasticsearch_http_enabled = {{ graylog_elasticsearch_http_enabled }}
+
+# Change the following setting if you are running into problems with timeouts during Elasticsearch cluster discovery.
+# The setting is specified in milliseconds, the default is 5000ms (5 seconds).
+elasticsearch_cluster_discovery_timeout = {{ graylog_elasticsearch_cluster_discovery_timeout }}
+
+# the following settings allow to change the bind addresses for the Elasticsearch client in Graylog
+# these settings are empty by default, letting Elasticsearch choose automatically,
+# override them here or in the 'elasticsearch_config_file' if you need to bind to a special address
+# refer to https://www.elastic.co/guide/en/elasticsearch/reference/2.3/modules-network.html
+# for special values here
+elasticsearch_network_host = {{ graylog_elasticsearch_network_host }}
+elasticsearch_network_bind_host = {{ graylog_elasticsearch_network_bind_host }}
+elasticsearch_network_publish_host = {{ graylog_elasticsearch_network_publish_host }}
+
+# The total amount of time discovery will look for other Elasticsearch nodes in the cluster
+# before giving up and declaring the current node master.
+elasticsearch_discovery_initial_state_timeout = {{ graylog_elasticsearch_discovery_initial_state_timeout }}
+{% endif %}
+
 # Analyzer (tokenizer) to use for message and full_message field. The "standard" filter usually is a good idea.
 # All supported analyzers are: standard, simple, whitespace, stop, keyword, pattern, language, snowball, custom
 # Elasticsearch documentation: https://www.elastic.co/guide/en/elasticsearch/reference/2.3/analysis.html


### PR DESCRIPTION
Update its role to be able to install graylog-server version minor or greater than 2.4.

Commit references of its removal: https://github.com/Graylog2/graylog-ansible-role/commit/0b74c1eb746e1c5f6a398e24af8e87e33cb14f9 and https://github.com/Graylog2/graylog-ansible-role/commit/708089139a0c394c13623c53594c3713c78d1e15