### PR TITLE
Raise dependency on jdauphant.nginx to latest upstream version v2.21.2

### DIFF
--- a/requirements.yml
+++ b/requirements.yml
@@ -6,4 +6,4 @@
 
 - name: "jdauphant.nginx"
   src: "https://github.com/jdauphant/ansible-role-nginx.git"
-  version: "v2.7.4"
+  version: "v2.21.2"


### PR DESCRIPTION
Fixes:

| `ERROR! 'always_run' is not a valid attribute for a Handler

Closes: #94