### PR TITLE
Fixing mongodb error after restarting at Red Hat

### DIFF
--- a/templates/mongodb.conf.j2
+++ b/templates/mongodb.conf.j2
@@ -24,11 +24,11 @@ net:
   port: 27017
   bindIp: 127.0.0.1
 
-
-{% if ansible_distribution != "RedHat" %}
+# how the process runs
 processManagement:
-  fork: false
-{% endif %}
+  fork: true  # fork and run in background
+  pidFilePath: /var/run/mongodb/mongod.pid  # location of pidfile
+  timeZoneInfo: /usr/share/zoneinfo
 
 #security:
 


### PR DESCRIPTION
With this template for the /etc/mongod.conf file, the service starts but does not recognize the pid file and then fails in the Red Hat environment. The fix allows mongodb to parse this pid file