### PR TITLE
Fix issue 92, only enable permission if SELInux is actually enabled

### DIFF
--- a/tasks/mongodb-RedHat.yml
+++ b/tasks/mongodb-RedHat.yml
@@ -48,6 +48,7 @@
     proto: "tcp"
     setype: "mongod_port_t"
     state: "present"
+  when: ansible_selinux.status == "enabled"
 
 - meta: "flush_handlers"
 


### PR DESCRIPTION
Fixes [issue 92](https://github.com/Graylog2/graylog-ansible-role/issues/92). 