### PR TITLE
Fix deprecation errors with Ansible 2.9

### DIFF
--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -12,9 +12,9 @@
   set_fact:
     use_system_d: >
       {{
-        (ansible_distribution == 'Debian' and ansible_distribution_version | version_compare('8', '>=')) or
-        (ansible_distribution in ['RedHat','CentOS'] and ansible_distribution_version | version_compare('7', '>=')) or
-        (ansible_distribution == 'Ubuntu' and ansible_distribution_version | version_compare('15', '>='))
+        (ansible_distribution == 'Debian' and ansible_distribution_version is version('8', '>=')) or
+        (ansible_distribution in ['RedHat','CentOS'] and ansible_distribution_version is version('7', '>=')) or
+        (ansible_distribution == 'Ubuntu' and ansible_distribution_version is version('15', '>='))
       }}
 
 - include: "mongodb-{{ ansible_os_family }}.yml"


### PR DESCRIPTION
This change fixes the following error:

```
template error while templating string: no filter named 'version_compare'. String: {{
  (ansible_distribution == 'Debian' and ansible_distribution_version | version_compare('8', '>=')) or
  (ansible_distribution in ['RedHat','CentOS'] and ansible_distribution_version | version_compare('7', '>=')) or
  (ansible_distribution == 'Ubuntu' and ansible_distribution_version | version_compare('15', '>='))
}}
```

