### PR TITLE
Change use of version_compare filter to version

### DIFF
--- a/README.md
+++ b/README.md
@@ -163,7 +163,7 @@ Note: in this example vars are in a more appropriate place at `group_vars/group/
         - "nginx"
         - "graylog_servers"
 
-    - role: "Graylog2.graylog-ansible-role"
+    - role: "graylog2.graylog-ansible-role"
       tags:
         - "graylog"
         - "graylog_servers"

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -12,9 +12,9 @@
   set_fact:
     use_system_d: >
       {{
-        (ansible_distribution == 'Debian' and ansible_distribution_version | version_compare('8', '>=')) or
-        (ansible_distribution in ['RedHat','CentOS'] and ansible_distribution_version | version_compare('7', '>=')) or
-        (ansible_distribution == 'Ubuntu' and ansible_distribution_version | version_compare('15', '>='))
+        (ansible_distribution == 'Debian' and ansible_distribution_version is version('8', '>=')) or
+        (ansible_distribution in ['RedHat','CentOS'] and ansible_distribution_version is version('7', '>=')) or
+        (ansible_distribution == 'Ubuntu' and ansible_distribution_version is version('15', '>='))
       }}
 
 - include: "mongodb-{{ ansible_os_family }}.yml"

--- a/tasks/setup-Debian.yml
+++ b/tasks/setup-Debian.yml
@@ -14,7 +14,7 @@
 - name: "Graylog repository package should be installed"
   apt:
     deb: "/tmp/graylog_repository.deb"
-    state: "installed"
+    state: "present"
     dpkg_options: "force-all"
   when: graylog_manage_apt_repo
   register: "install_repo"

--- a/tasks/setup-Debian.yml
+++ b/tasks/setup-Debian.yml
@@ -9,7 +9,7 @@
 - name: "Package 'apt-transport-https' should be installed"
   apt:
     name: "apt-transport-https"
-    state: "installed"
+    state: "present"
 
 - name: "Graylog repository package should be installed"
   apt:


### PR DESCRIPTION
The 'version_compare' filter was removed in 2.9 after being deprecated in 2.5.