### PR TITLE
Support ansible >=2.9: state 'installed' is deprecated

### DIFF
--- a/tasks/mongodb-RedHat.yml
+++ b/tasks/mongodb-RedHat.yml
@@ -12,7 +12,7 @@
 - name: "Package dependencies should be installed"
   yum:
     name: "{{ item }}"
-    state: "installed"
+    state: present
   with_items: "{{ graylog_mongodb_package_dependencies | default([]) }}"
 
 - name: "MongoDB should be installed"

--- a/tasks/setup-Debian.yml
+++ b/tasks/setup-Debian.yml
@@ -9,12 +9,12 @@
 - name: "Package 'apt-transport-https' should be installed"
   apt:
     name: "apt-transport-https"
-    state: "installed"
+    state: present
 
 - name: "Graylog repository package should be installed"
   apt:
     deb: "/tmp/graylog_repository.deb"
-    state: "installed"
+    state: present
     dpkg_options: "force-all"
   when: graylog_manage_apt_repo
   register: "install_repo"


### PR DESCRIPTION
State 'installed' is no longer supported as of ansible v2.9, adjust accordingly.