### PR TITLE
Upgrade default version to Graylog v3.1

### DIFF
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -6,7 +6,7 @@ graylog_java_repo:                 "deb http://ppa.launchpad.net/webupd8team/jav
 graylog_java_src_repo:             "deb-src http://ppa.launchpad.net/webupd8team/java/ubuntu xenial main"
 graylog_java_repo_keyserver:       "keyserver.ubuntu.com"
 graylog_java_repo_key:             "EEA14886"
-graylog_version:                   "3.0"
+graylog_version:                   "3.1"
 
 graylog_package_state:             "present"
 graylog_apt_deb_url:               "https://packages.graylog2.org/repo/packages/graylog-{{ graylog_version }}-repository_latest.deb"


### PR DESCRIPTION
Graylog 3.1.0 was released on 2019-08-16 and nowadays we're at version 3.1.3
(released on 2019-11-06).