### PR TITLE
Support ansible >=2.9: version_compare is deprecated

### DIFF
--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -12,9 +12,9 @@
   set_fact:
     use_system_d: >
       {{
-        (ansible_distribution == 'Debian' and ansible_distribution_version | version_compare('8', '>=')) or
-        (ansible_distribution in ['RedHat','CentOS'] and ansible_distribution_version | version_compare('7', '>=')) or
-        (ansible_distribution == 'Ubuntu' and ansible_distribution_version | version_compare('15', '>='))
+        (ansible_distribution == 'Debian' and ansible_distribution_version is version('8', '>=')) or
+        (ansible_distribution in ['RedHat','CentOS'] and ansible_distribution_version is version('7', '>=')) or
+        (ansible_distribution == 'Ubuntu' and ansible_distribution_version is version('15', '>='))
       }}
 
 - include: "mongodb-{{ ansible_os_family }}.yml"


### PR DESCRIPTION
In ansible v2.5 "version_compare" was renamed to "version",
and since ansible v2.9 it has been removed and therefore fails,
also see https://docs.ansible.com/ansible/latest/user_guide/playbooks_tests.html