### PR TITLE
JVM defaults: drop options no longer supported in recent Java versions

### DIFF
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -185,7 +185,7 @@ graylog_web_thread_pool_size:        16
 
 # JVM
 graylog_gc_warning_threshold: "1s"
-graylog_server_java_opts:     "-Djava.net.preferIPv4Stack=true -Xms1500m -Xmx1500m -XX:NewRatio=1 -server -XX:+ResizeTLAB -XX:+UseConcMarkSweepGC -XX:+CMSConcurrentMTEnabled -XX:+CMSClassUnloadingEnabled -XX:+UseParNewGC -XX:-OmitStackTraceInFastThrow"
+graylog_server_java_opts:     "-Djava.net.preferIPv4Stack=true -Xms1500m -Xmx1500m -XX:NewRatio=1 -server -XX:+ResizeTLAB -XX:+CMSConcurrentMTEnabled -XX:+CMSClassUnloadingEnabled -XX:-OmitStackTraceInFastThrow"
 graylog_server_args:          ""
 graylog_server_wrapper:       ""
 


### PR DESCRIPTION
On Debian/buster with openjdk-11-jre-headless graylog-server
fails to start with:

| graylog-server[31096]: OpenJDK 64-Bit Server VM warning: Option UseConcMarkSweepGC was deprecated in version 9.0 and will likely be removed in a future release
| graylog-server[31096]: Unrecognized VM option 'UseParNewGC'
| graylog-server[31096]: Error: Could not create the Java Virtual Machine.
| graylog-server[31096]: Error: A fatal exception has occurred. Program will exit.
| systemd[1]: graylog-server.service: Main process exited, code=exited, status=1/FAILURE
| systemd[1]: graylog-server.service: Failed with result 'exit-code'.

UseParNewGC was deprecated in JDK 9 and removed in JDK 10,
now defaulting to the G1 collector, also see
https://bugs.openjdk.java.net/browse/JDK-8151084

While at it disable the UseConcMarkSweepGC option, which
was also deprecated and will probably be removed in a later
version.