### PR TITLE
Ansible 2.9 deprecated option

### DIFF
--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -12,9 +12,9 @@
   set_fact:
     use_system_d: >
       {{
-        (ansible_distribution == 'Debian' and ansible_distribution_version | version_compare('8', '>=')) or
-        (ansible_distribution in ['RedHat','CentOS'] and ansible_distribution_version | version_compare('7', '>=')) or
-        (ansible_distribution == 'Ubuntu' and ansible_distribution_version | version_compare('15', '>='))
+        (ansible_distribution == 'Debian' and ansible_distribution_version is version_compare('8', '>=')) or
+        (ansible_distribution in ['RedHat','CentOS'] and ansible_distribution_version is version_compare('7', '>=')) or
+        (ansible_distribution == 'Ubuntu' and ansible_distribution_version is version_compare('15', '>='))
       }}
 
 - include: "mongodb-{{ ansible_os_family }}.yml"


### PR DESCRIPTION
Since Ansible 2.9 the syntax  "| version_compare" no longer works.