### PR TITLE
add in ability to supply arbitrary key/values for server config

### DIFF
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -198,3 +198,5 @@ graylog_install_java:          True
 
 # Disable steps which break tests
 graylog_not_testing:           True
+
+graylog_additional_config: {}

--- a/templates/graylog.server.conf.j2
+++ b/templates/graylog.server.conf.j2
@@ -641,3 +641,7 @@ dashboard_widget_default_cache_time = {{ graylog_dashboard_widget_default_cache_
 # of threads available for this. Increase it, if '/cluster/*' requests take long to complete.
 # Should be http_thread_pool_size * average_cluster_size if you have a high number of concurrent users.
 proxied_requests_thread_pool_size = {{ graylog_proxied_requests_thread_pool_size }}
+
+{% for key, value in graylog_additional_config.items() %}
+{{ key }} = {{ value }}
+{% endfor %}

--- a/tests/graylog.yml
+++ b/tests/graylog.yml
@@ -11,6 +11,9 @@
 
     graylog_not_testing:           False
 
+    graylog_additional_config:
+      test: value
+
     es_major_version: "5.x"
     es_instance_name: "graylog"
     es_scripts: False


### PR DESCRIPTION
Currently there is no way to add in configuration for any of the plugins. For example a [data reporter](https://github.com/graylog-labs/graylog-plugin-metrics-reporter/blob/master/metrics-reporter-datadog/README.md) requires configuration that is not able to get set with this role. This PR adds in the ability to add arbitrary `key = value` to the configuration file