### PR TITLE
Fix python setuptools install failure.

### DIFF
--- a/tests/support/jessie_22.Dockerfile
+++ b/tests/support/jessie_22.Dockerfile
@@ -8,7 +8,8 @@ RUN apt-get -y install ca-certificates \
                        python-pip \
                        python-dev \
                        libffi-dev
-RUN pip install -U cffi setuptools
+RUN pip install -U pip cffi
+RUN pip install -U setuptools==44.1.1
 RUN pip install ansible==2.5
 
 COPY run-tests.sh run-tests.sh


### PR DESCRIPTION
The CI job fails when trying to build the Debian Jessie Docker image. 

https://travis-ci.org/github/Graylog2/graylog-ansible-role/jobs/709374454

```
Downloading/unpacking setuptools from https://files.pythonhosted.org/packages/2f/8e/38259f4a44944a92068d5ff77230511a4c685604b47a81318f9e5cf2cc24/setuptools-49.2.0.zip#sha256=afe9e81fee0270d3f60d52608549cc8ec4c46dada8c95640c1a00160f577acf2
  Running setup.py (path:/tmp/pip-build-Jej3Q2/setuptools/setup.py) egg_info for package setuptools
    Traceback (most recent call last):
      File "<string>", line 3, in <module>
      File "setuptools/__init__.py", line 21, in <module>
        import setuptools.version
      File "setuptools/version.py", line 1, in <module>
        import pkg_resources
      File "pkg_resources/__init__.py", line 1380
        raise SyntaxError(e) from e
                                ^
    SyntaxError: invalid syntax
    Complete output from command python setup.py egg_info:
    Traceback (most recent call last):
  File "<string>", line 3, in <module>
  File "setuptools/__init__.py", line 21, in <module>
    import setuptools.version
  File "setuptools/version.py", line 1, in <module>
    import pkg_resources
  File "pkg_resources/__init__.py", line 1380
    raise SyntaxError(e) from e
                            ^
SyntaxError: invalid syntax
```


Playing around with installing different versions of setuptools, I found that installing version 46.0.0 gives this message:

```
    ************************************************************
    You are running Setuptools on Python 2, which is no longer
    supported and
    >>> SETUPTOOLS WILL STOP WORKING <<<
    in a subsequent release (no sooner than 2020-04-20).
    Please ensure you are installing
    Setuptools using pip 9.x or later or pin to `setuptools<45`
    in your environment.
    If you have done those things and are still encountering
    this message, please comment in
    https://github.com/pypa/setuptools/issues/1458
    about the steps that led to this unsupported combination.
    ************************************************************
```

This seems to be because python 2.7 is now deprecated. Setting the version of setuptools to `44.1.1` seems to fix the issue. 
