### PR TITLE
Various test enhancements

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -13,7 +13,6 @@ env:
   matrix:
     - MOLECULE_DISTRO: centos/7
     - MOLECULE_DISTRO: centos/8
-    - MOLECULE_DISTRO: debian/jessie64
     - MOLECULE_DISTRO: debian/stretch64
     - MOLECULE_DISTRO: debian/buster64
     - MOLECULE_DISTRO: generic/ubuntu1604

--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@ Dependencies
 - Java 8 - Ubuntu Xenial and up support OpenJDK 8 by default. For other distributions consider backports accordingly
 - [Elasticsearch][1]
 - [NGINX][2]
-- Tested on Ubuntu 16.04 / Ubuntu 18.04 / Debian 8 / Debian 9 / Debian 10 / Centos 7 / Centos 8
+- Tested on Ubuntu 16.04 / Ubuntu 18.04 / Debian 9 / Debian 10 / Centos 7 / Centos 8
 
 Quickstart
 ----------

--- a/README.md
+++ b/README.md
@@ -202,7 +202,7 @@ To destroy the VM:
 
     molecule destroy
 
-To test against other distros, you can also set the MOLECULE_DISTRO environment variable to:
+To test against other distros, you can also set the MOLECULE_DISTRO environment variable to one of these:
 
     export MOLECULE_DISTRO='centos/7'
     export MOLECULE_DISTRO='centos/8'

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -134,14 +134,15 @@ graylog_outputbuffer_processor_threads_core_pool_size: 3
 graylog_outputbuffer_processor_threads_max_pool_size:  30
 
 # MongoDB
-graylog_mongodb_ubuntu_repo:                         "deb [ arch=amd64,arm64 ] http://repo.mongodb.org/apt/ubuntu xenial/mongodb-org/3.6 multiverse"
+graylog_mongodb_version:                              4.2
+graylog_mongodb_ubuntu_repo:                         "deb [ arch=amd64,arm64 ] http://repo.mongodb.org/apt/ubuntu xenial/mongodb-org/{{ graylog_mongodb_version }} multiverse"
 graylog_mongodb_ubuntu_keyserver:                    "hkp://keyserver.ubuntu.com:80"
-graylog_mongodb_ubuntu_key:                          "2930ADAE8CAF5059EE73BB4B58712A2291FA4AD5"
-graylog_mongodb_debian_repo:                         "deb http://repo.mongodb.org/apt/debian {{ ansible_distribution_release }}/mongodb-org/3.6 main"
+graylog_mongodb_ubuntu_key:                          "4B7C549A058F8B6B"
+graylog_mongodb_debian_repo:                         "deb http://repo.mongodb.org/apt/debian {{ ansible_distribution_release }}/mongodb-org/{{ graylog_mongodb_version }} main"
 graylog_mongodb_debian_keyserver:                    "keyserver.ubuntu.com"
-graylog_mongodb_debian_key:                          "2930ADAE8CAF5059EE73BB4B58712A2291FA4AD5"
-graylog_mongodb_redhat_repo:                         "https://repo.mongodb.org/yum/redhat/$releasever/mongodb-org/3.6/x86_64/"
-graylog_mongodb_redhat_key:                          "https://www.mongodb.org/static/pgp/server-3.6.asc"
+graylog_mongodb_debian_key:                          "4B7C549A058F8B6B"
+graylog_mongodb_redhat_repo:                         "https://repo.mongodb.org/yum/redhat/$releasever/mongodb-org/{{ graylog_mongodb_version }}/x86_64/"
+graylog_mongodb_redhat_key:                          "https://www.mongodb.org/static/pgp/server-{{ graylog_mongodb_version }}.asc"
 
 graylog_mongodb_uri:                                 "mongodb://127.0.0.1:27017/graylog"
 graylog_mongodb_max_connections:                     100

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -135,7 +135,7 @@ graylog_outputbuffer_processor_threads_max_pool_size:  30
 
 # MongoDB
 graylog_mongodb_ubuntu_repo:                         "deb [ arch=amd64,arm64 ] http://repo.mongodb.org/apt/ubuntu xenial/mongodb-org/3.6 multiverse"
-graylog_mongodb_ubuntu_keyserver:                    "keyserver.ubuntu.com"
+graylog_mongodb_ubuntu_keyserver:                    "hkp://keyserver.ubuntu.com:80"
 graylog_mongodb_ubuntu_key:                          "2930ADAE8CAF5059EE73BB4B58712A2291FA4AD5"
 graylog_mongodb_debian_repo:                         "deb http://repo.mongodb.org/apt/debian {{ ansible_distribution_release }}/mongodb-org/3.6 main"
 graylog_mongodb_debian_keyserver:                    "keyserver.ubuntu.com"

--- a/meta/main.yml
+++ b/meta/main.yml
@@ -1,6 +1,10 @@
 ---
 
 dependencies:
+  - role: lean_delivery.java
+    version: 7.1.0
+    when: graylog_install_java
+
   - role: "elastic.elasticsearch"
     version: master
     when: graylog_install_elasticsearch

--- a/molecule/default/converge.yml
+++ b/molecule/default/converge.yml
@@ -32,7 +32,7 @@
       node.master: True
 
     #Java
-    transport: repositories
+    java_distribution: adoptopenjdk
     java_major_version: 8
 
     nginx_sites:

--- a/molecule/default/converge.yml
+++ b/molecule/default/converge.yml
@@ -4,7 +4,7 @@
   vars:
     #Graylog
     graylog_install_elasticsearch: True
-    graylog_install_mongodb:       False
+    graylog_install_mongodb:       True
     graylog_install_nginx:         False
     graylog_install_java:          True
     graylog_not_testing:           False

--- a/molecule/default/converge.yml
+++ b/molecule/default/converge.yml
@@ -2,12 +2,16 @@
 - name: Converge
   hosts: all
   vars:
-    graylog_install_elasticsearch: False
+    #Graylog
+    graylog_install_elasticsearch: True
     graylog_install_mongodb:       False
     graylog_install_nginx:         False
-    graylog_install_java:          False
+    graylog_install_java:          True
     graylog_not_testing:           False
 
+    graylog_web_endpoint_uri: "http://127.0.0.1:9000/api/"
+
+    #Elasticsearch
     es_major_version: "6.x"
     es_version: 6.8.10
     es_instance_name: "graylog"
@@ -15,6 +19,8 @@
     es_templates: False
     es_version_lock: False
     es_heap_size: "1g"
+    es_java_install: False
+    oss_version: True
 
     es_config:
       node.name: "graylog"
@@ -25,7 +31,9 @@
       node.data: True
       node.master: True
 
-    graylog_web_endpoint_uri: "http://127.0.0.1:9000/api/"
+    #Java
+    transport: repositories
+    java_major_version: 8
 
     nginx_sites:
       graylog:

--- a/molecule/default/molecule.yml
+++ b/molecule/default/molecule.yml
@@ -8,6 +8,10 @@ driver:
   name: vagrant
   provider:
     name: libvirt
+lint: |
+  set -e
+  yamllint .
+  #ansible-lint .
 platforms:
   - name: instance
     box: ${MOLECULE_DISTRO:-generic/ubuntu1804}

--- a/molecule/default/molecule.yml
+++ b/molecule/default/molecule.yml
@@ -11,7 +11,7 @@ driver:
 lint: |
   set -e
   yamllint .
-  #ansible-lint .
+  ansible-lint --exclude=$HOME/.ansible/roles/ -x 503
 platforms:
   - name: instance
     box: ${MOLECULE_DISTRO:-generic/ubuntu1804}

--- a/requirements.yml
+++ b/requirements.yml
@@ -1,4 +1,6 @@
 ---
+- role: lean_delivery.java
+  version: 7.1.0
 
 - name: "elastic.elasticsearch"
   src: "https://github.com/elastic/ansible-elasticsearch.git"

--- a/tasks/install-java.yml
+++ b/tasks/install-java.yml
@@ -1,6 +1,0 @@
----
-
-- name: "Ensure Java is installed"
-  package:
-    name: "{{ graylog_java }}"
-    state: "present"

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -20,9 +20,6 @@
 - include: "mongodb-{{ ansible_os_family }}.yml"
   when: graylog_install_mongodb
 
-- include: "install-java.yml"
-  when: graylog_install_java
-
 - include: "setup-{{ ansible_os_family }}.yml"
 
 - include: "server.yml"

--- a/tasks/mongodb-Debian.yml
+++ b/tasks/mongodb-Debian.yml
@@ -41,7 +41,7 @@
     group: "root"
     mode: 0644
   when:
-    - use_system_d
+    - use_system_d | bool
     - ansible_distribution == 'Ubuntu'
   notify:
     - "reload systemd configuration"

--- a/tasks/mongodb-RedHat.yml
+++ b/tasks/mongodb-RedHat.yml
@@ -11,9 +11,15 @@
 
 - name: "Package dependencies should be installed"
   yum:
-    name: "{{ item }}"
+    name: "{{ graylog_mongodb_package_dependencies_python2 }}"
     state: present
-  with_items: "{{ graylog_mongodb_package_dependencies | default([]) }}"
+  when: ansible_python_version is version('3.0.0', '<')
+
+- name: "Package dependencies should be installed"
+  yum:
+    name: "{{ graylog_mongodb_package_dependencies_python3 }}"
+    state: present
+  when: ansible_python_version is version('3.0.0', '>=')
 
 - name: "MongoDB should be installed"
   yum:

--- a/tasks/server.yml
+++ b/tasks/server.yml
@@ -6,7 +6,7 @@
     owner: "graylog"
     group: "graylog"
     mode: 0750
-    
+
 - name: "Make sure graylog-server directories exist"
   file:
     path: "{{ item }}"

--- a/templates/mongodb.conf.j2
+++ b/templates/mongodb.conf.j2
@@ -8,8 +8,6 @@ storage:
   dbPath: {{ graylog_mongodb_data_path }}
   journal:
     enabled: true
-  mmapv1:
-    smallFiles: true
 #  engine:
 #  wiredTiger:
 

--- a/vars/RedHat.yml
+++ b/vars/RedHat.yml
@@ -2,7 +2,10 @@
 
 graylog_server_defaults_file_path:    "/etc/sysconfig/graylog-server"
 graylog_mongodb_data_path:            "/var/lib/mongo"
-graylog_mongodb_package_dependencies:
+graylog_mongodb_package_dependencies_python2:
   - "libselinux-python"
   - "policycoreutils-python"
+graylog_mongodb_package_dependencies_python3:
+  - "python3-libselinux"
+  - "python3-policycoreutils"
 graylog_java:                         "java-1.8.0-openjdk-headless.x86_64"

--- a/vars/RedHat.yml
+++ b/vars/RedHat.yml
@@ -4,4 +4,5 @@ graylog_server_defaults_file_path:    "/etc/sysconfig/graylog-server"
 graylog_mongodb_data_path:            "/var/lib/mongo"
 graylog_mongodb_package_dependencies:
   - "libselinux-python"
+  - "policycoreutils-python"
 graylog_java:                         "java-1.8.0-openjdk-headless.x86_64"


### PR DESCRIPTION
Currently, the test playbook just installs Graylog. Ideally, it should start up Elasticsearch, Mongodb, and Graylog and ensure they start correctly. 