### PR TITLE
Make Mongodb version configurable.

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@ Dependencies
 ------------
 
 - **Only Ansible versions > 2.5.0 are supported.**
-- Java 8 - Ubuntu Xenial and up support OpenJDK 8 by default. For other distributions consider backports accordingly
+- Java 8 - Ubuntu Xenial and up support OpenJDK 8 by default. For other distributions, consider backports accordingly
 - [Elasticsearch][1]
 - [NGINX][2]
 - Tested on Ubuntu 16.04 / Ubuntu 18.04 / Debian 9 / Debian 10 / Centos 7 / Centos 8

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -202,4 +202,3 @@ graylog_additional_config: {}
 
 required_vars:
   - graylog_version
-  - graylog_mongodb_version

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -134,7 +134,7 @@ graylog_outputbuffer_processor_threads_core_pool_size: 3
 graylog_outputbuffer_processor_threads_max_pool_size:  30
 
 # MongoDB
-graylog_mongodb_ubuntu_repo:                         "deb [ arch=amd64,arm64 ] http://repo.mongodb.org/apt/ubuntu xenial/mongodb-org/{{ graylog_mongodb_version }} multiverse"
+graylog_mongodb_ubuntu_repo:                         "deb [ arch=amd64,arm64 ] http://repo.mongodb.org/apt/ubuntu {{ ansible_distribution_release }}/mongodb-org/{{ graylog_mongodb_version }} multiverse"
 graylog_mongodb_ubuntu_keyserver:                    "hkp://keyserver.ubuntu.com:80"
 graylog_mongodb_ubuntu_key:                          "4B7C549A058F8B6B"
 graylog_mongodb_debian_repo:                         "deb http://repo.mongodb.org/apt/debian {{ ansible_distribution_release }}/mongodb-org/{{ graylog_mongodb_version }} main"

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -134,7 +134,6 @@ graylog_outputbuffer_processor_threads_core_pool_size: 3
 graylog_outputbuffer_processor_threads_max_pool_size:  30
 
 # MongoDB
-graylog_mongodb_version:                              4.2
 graylog_mongodb_ubuntu_repo:                         "deb [ arch=amd64,arm64 ] http://repo.mongodb.org/apt/ubuntu xenial/mongodb-org/{{ graylog_mongodb_version }} multiverse"
 graylog_mongodb_ubuntu_keyserver:                    "hkp://keyserver.ubuntu.com:80"
 graylog_mongodb_ubuntu_key:                          "4B7C549A058F8B6B"

--- a/molecule/default/converge.yml
+++ b/molecule/default/converge.yml
@@ -10,6 +10,7 @@
     graylog_not_testing:           False
 
     graylog_web_endpoint_uri: "http://127.0.0.1:9000/api/"
+    graylog_mongodb_version:  4.2
 
     #Elasticsearch
     es_major_version: "6.x"

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -10,6 +10,9 @@
   when: item not in vars
   with_items: "{{ required_vars }}"
 
+- fail: msg="The 'graylog_mongodb_version' variable is not defined."
+  when: (graylog_install_mongodb == True) and (graylog_mongodb_version is not defined)
+
 - name: "Check deprecated variables"
   fail:
     msg: "Varible 'graylog_server_version' has been deprecated. Use 'graylog_full_version' instead."

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -5,6 +5,9 @@
     msg: "Distro {{ ansible_distribution }} is not supported yet."
   when: ansible_os_family not in graylog_supported_os_families
 
+- fail: msg="The 'graylog_mongodb_version' variable is not defined."
+  when: (graylog_install_mongodb == True) and (graylog_mongodb_version is not defined)
+
 - name: "Load OS-family specific vars"
   include_vars: "{{ ansible_os_family }}.yml"
 


### PR DESCRIPTION
The version of MongoDB should be configurable, not hardcoded. At the same time, I am wary of surprise-updating someone's MongoDB instance. I think it should be opt-in, so people can upgrade when they want and ensure they are ready for it. The user should tell us what version of MongoDB they want.

This will make it so that if someones specifies `graylog_install_mongodb: True`, then they will also need to specify `graylog_mongodb_version` and the key for the package repo. If they specify `graylog_install_mongodb: False`, then nothing will change, as the code will be ignored.

