### PR TITLE
Attempt to fix service tests.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -27,7 +27,7 @@ install:
     sudo dpkg -i vagrant_${VAGRANT_VERSION}_x86_64.deb
     vagrant --version
   - sudo vagrant plugin install vagrant-libvirt
-  - pip3 install molecule yamllint ansible-lint python-vagrant molecule-vagrant
+  - pip3 install molecule yamllint ansible-lint python-vagrant molecule-vagrant testinfra
   - sudo chown -R travis:travis /home/travis/.vagrant.d
   - sudo gpasswd -a travis libvirt
 

--- a/molecule/default/molecule.yml
+++ b/molecule/default/molecule.yml
@@ -32,5 +32,5 @@ providers:
     driver: kvm
 provisioner:
   name: ansible
-#verifier:
-#  name: testinfra
+verifier:
+ name: testinfra

--- a/molecule/default/verify.yml
+++ b/molecule/default/verify.yml
@@ -1,9 +1,0 @@
----
-# This is an example playbook to execute Ansible tests.
-
-- name: Verify
-  hosts: all
-  tasks:
-  - name: Example assertion
-    assert:
-      that: true


### PR DESCRIPTION
Fixing this error in Travis CI:

```
--> Scenario: 'default'
--> Action: 'verify'
--> Executing Testinfra tests found in /home/travis/build/Graylog2/graylog-ansible-role/molecule/default/tests/...
ERROR: usage: pytest [options] [file_or_dir] [file_or_dir] [...]
pytest: error: unrecognized arguments: --ansible-inventory=/home/travis/.cache/molecule/graylog-ansible-role/default/inventory/ansible_inventory.yml --connection=ansible
  inifile: None
  rootdir: /home/travis/build/Graylog2/graylog-ansible-role/molecule/default
```

https://travis-ci.org/github/Graylog2/graylog-ansible-role/jobs/711097325