### PR TITLE
Make graylog_server var required.

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,7 +37,13 @@ Dependencies
 - Java 8 - Ubuntu Xenial and up support OpenJDK 8 by default. For other distributions consider backports accordingly
 - [Elasticsearch][1]
 - [NGINX][2]
-- Tested on Ubuntu 16.04 / Ubuntu 18.04 / Debian 9 / Debian 10 / Centos 7 / Centos 8
+- Tested on
+  - Ubuntu 16.04
+  - Ubuntu 18.04
+  - Debian 9
+  - Debian 10
+  - Centos 7
+  - Centos 8
 - This role is for Graylog-3.X only!
   - For older versions, use the graylog-2.X branch.
 

--- a/README.md
+++ b/README.md
@@ -1,11 +1,40 @@
 [![Build Status](https://travis-ci.org/Graylog2/graylog-ansible-role.svg?branch=master)](https://travis-ci.org/Graylog2/graylog-ansible-role)
 
+[![Galaxy](https://img.shields.io/badge/galaxy-graylog--ansible--role-blue)](https://galaxy.ansible.com/graylog2/graylog-ansible-role)
+
+![Ansible](https://img.shields.io/ansible/role/d/11230.svg)
+
+![Ansible](https://img.shields.io/badge/dynamic/json.svg?label=min_ansible_version&url=https%3A%2F%2Fgalaxy.ansible.com%2Fapi%2Fv1%2Froles%2F11230%2F&query=$.min_ansible_version)
+
+![Ansible](https://img.shields.io/ansible/quality/11230)
 Description
 -----------
 
-Ansible role which installs and configures Graylog log management.
+An Ansible role which installs and configures [Graylog](https://docs.graylog.org) for log management.
 
-**THIS ROLE IS FOR GRAYLOG-3.X ONLY! FOR OLDER VERSIONS USE THE `GRAYLOG-2.X` BRANCH!**
+Changelog
+---
+####  v3.3
+
+- **Breaking changes in this release**:
+  - The `graylog_version` variable must now be explicitly declared.
+    - Renamed the optional `graylog_server_version` variable to `graylog_full_version`. If not set, it will pull the latest `graylog_version` defined.
+  - Increased the minimum Ansible version from 2.2 to 2.5.
+  - No longer testing the Ansible role against Debian Jessie.
+- New stuff:
+  - Added ability to supply arbitrary key/values for server config [PR #142](https://github.com/Graylog2/graylog-ansible-role/pull/142)
+  Example:
+
+    ```
+    graylog_additional_config:
+      test: value   
+    ```
+- Fixes:
+  - Only enable permission if SELInux is actually enabled - [PR #121](https://github.com/Graylog2/graylog-ansible-role/pull/121)
+  - Make sure graylog-server directories exist - [PR #134](https://github.com/Graylog2/graylog-ansible-role/pull/134)
+  - Fixed missing policycoreutils-python package on Centos 7 - [Issue #119](https://github.com/Graylog2/graylog-ansible-role/issues/119)
+
+
 
 Dependencies
 ------------
@@ -15,6 +44,8 @@ Dependencies
 - [Elasticsearch][1]
 - [NGINX][2]
 - Tested on Ubuntu 16.04 / Ubuntu 18.04 / Debian 9 / Debian 10 / Centos 7 / Centos 8
+- This role is for Graylog-3.X only!
+  - For older versions, use the graylog-2.X branch.
 
 Quickstart
 ----------
@@ -40,6 +71,7 @@ Here is an example of a playbook targeting Vagrant (Ubuntu Xenial):
       http.port: 9200
       transport.tcp.port: 9300
       network.host: "127.0.0.1"
+    graylog_version: 3.3
     graylog_install_java: False # Elasticsearch role already installed Java
     graylog_password_secret: "2jueVqZpwLLjaWxV" # generate with: pwgen -s 96 1
     graylog_root_password_sha2: "8c6976e5b5410415bde908bd4dee15dfb167a9c873fc4bb8a81f6f2ab448a918"
@@ -63,9 +95,10 @@ Variables
 
 ```yaml
 # Basic server settings
-graylog_server_version:     "3.0.1-1" # Optional, if not provided the latest version will be installed
-graylog_is_master:          "True"
-graylog_password_secret:    "2jueVqZpwLLjaWxV" # generate with: pwgen -s 96 1
+graylog_version: 3.3     # Required
+graylog_full_version: "3.3.2-1" # Optional, if not provided, the latest revision of {{ graylog_version }} will be installed
+graylog_is_master: "True"
+graylog_password_secret: "2jueVqZpwLLjaWxV" # generate with: pwgen -s 96 1
 graylog_root_password_sha2: "8c6976e5b5410415bde908bd4dee15dfb167a9c873fc4bb8a81f6f2ab448a918"
 
 graylog_http_bind_address: "{{ ansible_default_ipv4.address }}:9000"
@@ -100,6 +133,7 @@ More detailed example
       network.host: "127.0.0.1"
       node.data: True
       node.master: True
+    graylog_version: 3.3
     graylog_install_java: False # Elasticsearch role already installed Java
     graylog_password_secret: "2jueVqZpwLLjaWxV" # generate with: pwgen -s 96 1
     graylog_root_password_sha2: "8c6976e5b5410415bde908bd4dee15dfb167a9c873fc4bb8a81f6f2ab448a918"
@@ -152,6 +186,9 @@ Note: in this example vars are in a more appropriate place at `group_vars/group/
     graylog_install_nginx:         False
 
   roles:
+    - role: lean_delivery.java
+      version: 7.1.0
+      when: graylog_install_java
 
     - role: "elastic.elasticsearch"
       tags:

--- a/README.md
+++ b/README.md
@@ -44,11 +44,12 @@ Dependencies
   - Debian 10
   - Centos 7
   - Centos 8
-- This role is for Graylog-3.X only!
-  - For older versions, use the graylog-2.X branch.
 
-Quickstart
+
+Usage
 ----------
+
+*Note: This role is for Graylog-3.X only! For older versions, use the graylog-2.X branch.*
 
 - You need at least 4GB of memory to run Graylog
 - Generate the password hash for the admin user:

--- a/README.md
+++ b/README.md
@@ -1,12 +1,4 @@
-[![Build Status](https://travis-ci.org/Graylog2/graylog-ansible-role.svg?branch=master)](https://travis-ci.org/Graylog2/graylog-ansible-role)
-
-[![Galaxy](https://img.shields.io/badge/galaxy-graylog--ansible--role-blue)](https://galaxy.ansible.com/graylog2/graylog-ansible-role)
-
-![Ansible](https://img.shields.io/ansible/role/d/11230.svg)
-
-![Ansible](https://img.shields.io/badge/dynamic/json.svg?label=min_ansible_version&url=https%3A%2F%2Fgalaxy.ansible.com%2Fapi%2Fv1%2Froles%2F11230%2F&query=$.min_ansible_version)
-
-![Ansible](https://img.shields.io/ansible/quality/11230)
+[![Build Status](https://travis-ci.org/Graylog2/graylog-ansible-role.svg?branch=master)](https://travis-ci.org/Graylog2/graylog-ansible-role) [![Galaxy](https://img.shields.io/badge/galaxy-graylog--ansible--role-blue)](https://galaxy.ansible.com/graylog2/graylog-ansible-role) ![Ansible](https://img.shields.io/ansible/role/d/11230.svg) ![Ansible](https://img.shields.io/badge/dynamic/json.svg?label=min_ansible_version&url=https%3A%2F%2Fgalaxy.ansible.com%2Fapi%2Fv1%2Froles%2F11230%2F&query=$.min_ansible_version) ![Ansible](https://img.shields.io/ansible/quality/11230)
 Description
 -----------
 

--- a/README.md
+++ b/README.md
@@ -1,4 +1,5 @@
 [![Build Status](https://travis-ci.org/Graylog2/graylog-ansible-role.svg?branch=master)](https://travis-ci.org/Graylog2/graylog-ansible-role) [![Galaxy](https://img.shields.io/badge/galaxy-graylog--ansible--role-blue)](https://galaxy.ansible.com/graylog2/graylog-ansible-role) ![Ansible](https://img.shields.io/ansible/role/d/11230.svg) ![Ansible](https://img.shields.io/badge/dynamic/json.svg?label=min_ansible_version&url=https%3A%2F%2Fgalaxy.ansible.com%2Fapi%2Fv1%2Froles%2F11230%2F&query=$.min_ansible_version) ![Ansible](https://img.shields.io/ansible/quality/11230)
+
 Description
 -----------
 

--- a/README.md
+++ b/README.md
@@ -16,7 +16,8 @@ Changelog
   - No longer testing the Ansible role against Debian Jessie.
 - New stuff:
   - Added ability to supply arbitrary key/values for server config [PR #142](https://github.com/Graylog2/graylog-ansible-role/pull/142)
-  Example:
+
+    Example:
 
     ```
     graylog_additional_config:

--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@ Changelog
 ---
 ####  v3.3
 
-- **Breaking changes in this release**:
+- **Breaking changes**:
   - The `graylog_version` variable must now be explicitly declared.
   - Renamed the optional `graylog_server_version` variable to `graylog_full_version`. If not set, it will pull the latest `graylog_version` defined.
   - Increased the minimum Ansible version from 2.2 to 2.5.

--- a/README.md
+++ b/README.md
@@ -34,7 +34,7 @@ Dependencies
 ------------
 
 - **Only Ansible versions > 2.5.0 are supported.**
-- Java 8 - Ubuntu Xenial and up support OpenJDK 8 by default. For other distributions consider backports accordingly
+- Java 8 - Ubuntu Xenial and up support OpenJDK 8 by default. For other distributions, consider backports accordingly
 - [Elasticsearch][1]
 - [NGINX][2]
 - Tested on

--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@ Changelog
 
 - **Breaking changes in this release**:
   - The `graylog_version` variable must now be explicitly declared.
-    - Renamed the optional `graylog_server_version` variable to `graylog_full_version`. If not set, it will pull the latest `graylog_version` defined.
+  - Renamed the optional `graylog_server_version` variable to `graylog_full_version`. If not set, it will pull the latest `graylog_version` defined.
   - Increased the minimum Ansible version from 2.2 to 2.5.
   - No longer testing the Ansible role against Debian Jessie.
 - New stuff:

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -6,7 +6,6 @@ graylog_java_repo:                 "deb http://ppa.launchpad.net/webupd8team/jav
 graylog_java_src_repo:             "deb-src http://ppa.launchpad.net/webupd8team/java/ubuntu xenial main"
 graylog_java_repo_keyserver:       "keyserver.ubuntu.com"
 graylog_java_repo_key:             "EEA14886"
-graylog_version:                   "3.1"
 
 graylog_package_state:             "present"
 graylog_apt_deb_url:               "https://packages.graylog2.org/repo/packages/graylog-{{ graylog_version }}-repository_latest.deb"
@@ -201,3 +200,6 @@ graylog_install_java:          True
 graylog_not_testing:           True
 
 graylog_additional_config: {}
+
+required_vars:
+  - graylog_version

--- a/meta/main.yml
+++ b/meta/main.yml
@@ -19,16 +19,18 @@ galaxy_info:
   min_ansible_version: "2.5"
   license: "Apache 2"
   platforms:
+    - name: "CentOS"
+      versions:
+        - "7"
+        - "8"
+    - name: "Debian"
+      versions:
+        - "stretch"
+        - "buster"
     - name: "Ubuntu"
       versions:
         - "xenial"
-        - "zesty"
-    - name: "Debian"
-      versions:
-        - "jessie"
-    - name: "EL"
-      versions:
-        - "7"
+        - "bionic"
   galaxy_tags:
     - "monitoring"
     - "system"

--- a/molecule/default/converge.yml
+++ b/molecule/default/converge.yml
@@ -8,7 +8,7 @@
     graylog_install_nginx:         False
     graylog_install_java:          True
     graylog_not_testing:           False
-
+    graylog_version:               3.3
     graylog_web_endpoint_uri: "http://127.0.0.1:9000/api/"
 
     #Elasticsearch

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -5,6 +5,11 @@
     msg: "Distro {{ ansible_distribution }} is not supported yet."
   when: ansible_os_family not in graylog_supported_os_families
 
+- name: "Check required variables"
+  fail: msg="Variable '{{ item }}' is not defined"
+  when: item not in vars
+  with_items: "{{required_vars}}"
+
 - name: "Load OS-family specific vars"
   include_vars: "{{ ansible_os_family }}.yml"
 

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -8,7 +8,7 @@
 - name: "Check required variables"
   fail: msg="Variable '{{ item }}' is not defined"
   when: item not in vars
-  with_items: "{{required_vars}}"
+  with_items: "{{ required_vars }}"
 
 - name: "Load OS-family specific vars"
   include_vars: "{{ ansible_os_family }}.yml"

--- a/tasks/setup-Debian.yml
+++ b/tasks/setup-Debian.yml
@@ -26,7 +26,7 @@
 
 - name: "Graylog server package should be installed"
   apt:
-    name: "graylog-server{% if graylog_server_version is defined %}={{ graylog_server_version }}{% endif %}"
+    name: "graylog-server{% if graylog_full_version is defined %}={{ graylog_full_version }}{% endif %}"
     state: "{{ graylog_package_state }}"
   notify: "restart graylog-server"
 

--- a/tasks/setup-RedHat.yml
+++ b/tasks/setup-RedHat.yml
@@ -9,6 +9,6 @@
 
 - name: "Graylog server should be installed"
   yum:
-    name: "graylog-server{% if graylog_server_version is defined %}-{{ graylog_server_version }}{% endif %}"
+    name: "graylog-server{% if graylog_full_version is defined %}-{{ graylog_full_version }}{% endif %}"
     state: "{{ graylog_package_state }}"
   notify: restart graylog-server


### PR DESCRIPTION
Making the `graylog_version` variable required, so that people can opt-in to the Graylog version they want. Otherwise, when we update the default value, we might break installs. 

Also updated the docs a bit.
