### PR TITLE
Make MongoDB IP and port binding configurable

### DIFF
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -145,6 +145,8 @@ graylog_mongodb_max_connections:                     100
 graylog_mongodb_threads_allowed_to_block_multiplier: 5
 graylog_mongodb_package_name:                        mongodb-org
 graylog_mongodb_service_name:                        mongod
+graylog_mongodb_bind_ip:                             "127.0.0.1"
+graylog_mongodb_bind_port:                           "27017"
 
 # Drools
 graylog_rules_file: ""

--- a/tasks/mongodb-Debian.yml
+++ b/tasks/mongodb-Debian.yml
@@ -66,7 +66,7 @@
 - meta: "flush_handlers"
 - name: "Wait for MongoDB to startup"
   wait_for:
-    host: "127.0.0.1"
-    port: 27017
+    host: "{{graylog_mongodb_bind_ip}}"
+    port: "{{graylog_mongodb_bind_port}}"
     delay: 5
     connect_timeout: 1

--- a/tasks/mongodb-RedHat.yml
+++ b/tasks/mongodb-RedHat.yml
@@ -50,7 +50,7 @@
 
 - name: "SELinux port access should be granted for MongoDB"
   seport:
-    ports: 27017
+    ports: "{{graylog_mongodb_bind_port}}"
     proto: "tcp"
     setype: "mongod_port_t"
     state: "present"
@@ -60,7 +60,7 @@
 
 - name: "Wait for MongoDB to startup"
   wait_for:
-    host: "127.0.0.1"
-    port: 27017
+    host: "{{graylog_mongodb_bind_ip}}"
+    port: "{{graylog_mongodb_bind_port}}"
     delay: 5
     connect_timeout: 1

--- a/templates/mongodb.conf.j2
+++ b/templates/mongodb.conf.j2
@@ -19,8 +19,8 @@ systemLog:
 
 # network interfaces
 net:
-  port: 27017
-  bindIp: 127.0.0.1
+  port: {{ graylog_mongodb_bind_port }}
+  bindIp: {{ graylog_mongodb_bind_ip }}
 
 
 {% if ansible_distribution != "RedHat" %}


### PR DESCRIPTION
Theres not much more to add. Default behaviour remains the same. 