### PR TITLE
Updating mongodb.conf template to make it work on RedHat derivatives as well

### DIFF
--- a/molecule/default/tests/test_default.py
+++ b/molecule/default/tests/test_default.py
@@ -3,12 +3,7 @@ def test_service_elasticsearch_running(host):
     assert host.service("elasticsearch").is_running is True
 
 def test_service_mongodb_running(host):
-    if host.system_info.distribution == 'ubuntu' and host.system_info.codename == 'focal':
-        mongodb_service_name = 'mongodb'
-    else:
-        mongodb_service_name = 'mongod'
-
-    assert host.service(mongodb_service_name).is_running is True
+    assert host.service("mongod").is_running is True
 
 def test_is_graylog_installed(host):
     assert host.package('graylog-server').is_installed

--- a/templates/mongodb.conf.j2
+++ b/templates/mongodb.conf.j2
@@ -23,9 +23,13 @@ net:
   bindIp: {{ graylog_mongodb_bind_ip }}
 
 
-{% if ansible_os_family != "RedHat" %}
 processManagement:
+{% if ansible_os_family != "RedHat" %}
   fork: false
+{% else %}
+  fork: true  # fork and run in background
+  pidFilePath: /var/run/mongodb/mongod.pid  # location of pidfile
+  timeZoneInfo: /usr/share/zoneinfo
 {% endif %}
 
 #security:

--- a/templates/mongodb.conf.j2
+++ b/templates/mongodb.conf.j2
@@ -23,7 +23,7 @@ net:
   bindIp: {{ graylog_mongodb_bind_ip }}
 
 
-{% if ansible_distribution != "RedHat" %}
+{% if ansible_os_family != "RedHat" %}
 processManagement:
   fork: false
 {% endif %}


### PR DESCRIPTION
Hi,

The role currently deploys a mongodb.conf file which does not work on CentOS or any other RedHat derivatives, nor on RedHat itself.

In this PR mongodb.conf's template have been updated with matching configuration from the original rpm config file to ensure that the role works on RedHat (and derivatives) as well.

[https://github.com/mongodb/mongo/blob/master/rpm/mongod.conf#L21]()

Thanks,
Frank