### PR TITLE
Fix failing mongodb test on ubuntu 20.04

### DIFF
--- a/molecule/default/tests/test_default.py
+++ b/molecule/default/tests/test_default.py
@@ -3,12 +3,7 @@ def test_service_elasticsearch_running(host):
     assert host.service("elasticsearch").is_running is True
 
 def test_service_mongodb_running(host):
-    if host.system_info.distribution == 'ubuntu' and host.system_info.codename == 'focal':
-        mongodb_service_name = 'mongodb'
-    else:
-        mongodb_service_name = 'mongod'
-
-    assert host.service(mongodb_service_name).is_running is True
+    assert host.service("mongod").is_running is True
 
 def test_is_graylog_installed(host):
     assert host.package('graylog-server').is_installed


### PR DESCRIPTION
Making an attempt to fix the failing CI test on Ubuntu 20.04. I don't think that the service is called there mongodb, I think it is just mongod like everywhere else. Let's hope the test passes.