### PR TITLE
Remove Nginx dependency

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,21 +12,20 @@ Dependencies
 - **Only Ansible versions > 2.5.0 are supported.**
 - Java 8 - Ubuntu Xenial and up support OpenJDK 8 by default. For other distributions, consider backports accordingly
 - [Elasticsearch][1]
-- [NGINX][2]
 - Tested on
   - Ubuntu 16.04
   - Ubuntu 18.04
+  - Ubuntu 20.04
   - Debian 9
   - Debian 10
   - Centos 7
   - Centos 8
 
+If you require Nginx to be installed, include the official [Nginx][2] role in your playbook.
+
 
 Usage
 ----------
-
-*Note: This role is for Graylog-3.X only! For older versions, use the graylog-2.X branch.*
-
 - You need at least 4GB of memory to run Graylog
 - Generate the password hash for the admin user:
   - `echo -n yourpassword | sha256sum     # Linux`
@@ -72,8 +71,8 @@ Variables
 
 ```yaml
 # Basic server settings
-graylog_version: 3.3     # Required
-graylog_full_version: "3.3.2-1" # Optional, if not provided, the latest revision of {{ graylog_version }} will be installed
+graylog_version: 4.0     # Required
+graylog_full_version: "4.0.6-1" # Optional, if not provided, the latest revision of {{ graylog_version }} will be installed
 graylog_is_master: "True"
 graylog_password_secret: "2jueVqZpwLLjaWxV" # generate with: pwgen -s 96 1
 graylog_root_password_sha2: "8c6976e5b5410415bde908bd4dee15dfb167a9c873fc4bb8a81f6f2ab448a918"
@@ -119,32 +118,13 @@ More detailed example
       network.host: "127.0.0.1"
       node.data: True
       node.master: True
-    graylog_version: 3.3
+    graylog_version: 4.0
     graylog_install_java: False # Elasticsearch role already installed Java
     graylog_password_secret: "2jueVqZpwLLjaWxV" # generate with: pwgen -s 96 1
     graylog_root_password_sha2: "8c6976e5b5410415bde908bd4dee15dfb167a9c873fc4bb8a81f6f2ab448a918"
     graylog_http_bind_address: "{{ ansible_default_ipv4.address }}:9000"
     graylog_http_publish_uri: "http://{{ ansible_default_ipv4.address }}:9000/"
     graylog_http_external_uri: "http://{{ ansible_default_ipv4.address }}:9000/"
-
-    nginx_sites:
-      graylog:
-        - "listen 80"
-        - "server_name graylog"
-        - |
-          location / {
-            proxy_pass http://localhost:9000/;
-            proxy_set_header Host $host;
-            proxy_set_header X-Real-IP $remote_addr;
-            proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
-            proxy_pass_request_headers on;
-            proxy_connect_timeout 150;
-            proxy_send_timeout 100;
-            proxy_read_timeout 100;
-            proxy_buffers 4 32k;
-            client_max_body_size 8m;
-            client_body_buffer_size 128k;
-          }
 
   roles:
     - role: "graylog2.graylog-ansible-role"
@@ -169,7 +149,6 @@ Note: in this example vars are in a more appropriate place at `group_vars/group/
   vars:
     graylog_install_elasticsearch: False
     graylog_install_mongodb:       False
-    graylog_install_nginx:         False
 
   roles:
     - role: lean_delivery.java
@@ -179,11 +158,6 @@ Note: in this example vars are in a more appropriate place at `group_vars/group/
     - role: "elastic.elasticsearch"
       tags:
         - "elasticsearch"
-        - "graylog_servers"
-
-    - role: "jdauphant.nginx"
-      tags:
-        - "nginx"
         - "graylog_servers"
 
     - role: "graylog2.graylog-ansible-role"
@@ -302,7 +276,7 @@ Author: Marius Sturm (<marius@graylog.com>) and [contributors][4]
 License: Apache 2.0
 
 [1]: https://github.com/elastic/ansible-elasticsearch
-[2]: https://github.com/jdauphant/ansible-role-nginx
+[2]: https://github.com/nginxinc/ansible-role-nginx
 [3]: https://github.com/Graylog2/graylog-ansible-role/blob/master/meta/main.yml
 [4]: https://github.com/Graylog2/graylog2-ansible-role/graphs/contributors
 [5]: https://pablodav.github.io/post/graylog/graylog_ansible

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -194,6 +194,7 @@ graylog_server_wrapper:       ""
 # Install Switches
 graylog_install_elasticsearch: True
 graylog_install_mongodb:       True
+graylog_install_nginx:         False    #Deprecated
 graylog_install_java:          True
 
 # Disable steps which break tests

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -194,7 +194,6 @@ graylog_server_wrapper:       ""
 # Install Switches
 graylog_install_elasticsearch: True
 graylog_install_mongodb:       True
-graylog_install_nginx:         True
 graylog_install_java:          True
 
 # Disable steps which break tests

--- a/meta/main.yml
+++ b/meta/main.yml
@@ -28,6 +28,7 @@ galaxy_info:
       versions:
         - "xenial"
         - "bionic"
+        - "focal"
   galaxy_tags:
     - "monitoring"
     - "system"

--- a/meta/main.yml
+++ b/meta/main.yml
@@ -9,9 +9,6 @@ dependencies:
     version: master
     when: graylog_install_elasticsearch
 
-  - role: "jdauphant.nginx"
-    when: graylog_install_nginx
-
 galaxy_info:
   author: "Marius Sturm"
   company: "Graylog, Inc."

--- a/molecule/default/converge.yml
+++ b/molecule/default/converge.yml
@@ -5,7 +5,6 @@
     #Graylog
     graylog_install_elasticsearch: True
     graylog_install_mongodb:       True
-    graylog_install_nginx:         False
     graylog_install_java:          False
     graylog_not_testing:           False
     graylog_version:               3.3

--- a/molecule/ui/converge.yml
+++ b/molecule/ui/converge.yml
@@ -5,7 +5,6 @@
     #Graylog
     graylog_install_elasticsearch: True
     graylog_install_mongodb:       True
-    graylog_install_nginx:         False
     graylog_install_java:          False
     graylog_not_testing:           False
     graylog_version:               "{{ lookup('env', 'GRAYLOG_VERSION') | regex_search('^\\d+\\.\\d+') }}"
@@ -37,24 +36,6 @@
       network.host: "0.0.0.0"
       node.data: True
       node.master: True
-
-    nginx_sites:
-      graylog:
-        - "listen 80"
-        - |
-          location / {
-            proxy_pass http://{{ hostvars[inventory_hostname]['ansible_default_ipv4']['address'] }}:9000/;
-            proxy_set_header Host $host;
-            proxy_set_header X-Real-IP $remote_addr;
-            proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
-            proxy_pass_request_headers on;
-            proxy_connect_timeout 150;
-            proxy_send_timeout 100;
-            proxy_read_timeout 100;
-            proxy_buffers 4 32k;
-            client_max_body_size 8m;
-            client_body_buffer_size 128k;
-          }
 
     #Plugins
     graylog_install_enterprise_plugins:               True

--- a/requirements.yml
+++ b/requirements.yml
@@ -5,7 +5,3 @@
 - name: "elastic.elasticsearch"
   src: "https://github.com/elastic/ansible-elasticsearch.git"
   version: master
-
-- name: "jdauphant.nginx"
-  src: "https://github.com/jdauphant/ansible-role-nginx.git"
-  version: "v2.22"

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -22,7 +22,7 @@
 - name: "Check deprecated variables: graylog_install_nginx"
   fail:
     msg: "Varible 'graylog_install_nginx' has been deprecated. Use the official Nginx role to install Nginx."
-  when: graylog_install_nginx is defined
+  when: graylog_install_nginx
 
 - name: "Load OS-family specific vars"
   include_vars: "{{ ansible_os_family }}.yml"

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -16,7 +16,7 @@
 
 - name: "Check deprecated variables: graylog_server_version"
   fail:
-    msg: "Varible 'graylog_server_version' has been deprecated. Use 'graylog_full_version' instead."
+    msg: "Variable 'graylog_server_version' has been deprecated. Use 'graylog_full_version' instead."
   when: graylog_server_version is defined
 
 - name: "Check deprecated variables: graylog_install_nginx"

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -22,7 +22,7 @@
 - name: "Check deprecated variables: graylog_install_nginx"
   fail:
     msg: "Varible 'graylog_install_nginx' has been deprecated. Use the official Nginx role to install Nginx."
-  when: graylog_install_nginx
+  when: graylog_install_nginx is defined
 
 - name: "Load OS-family specific vars"
   include_vars: "{{ ansible_os_family }}.yml"

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -14,10 +14,15 @@
   fail: msg="The 'graylog_mongodb_version' variable is not defined."
   when: (graylog_install_mongodb) and (graylog_mongodb_version is not defined)
 
-- name: "Check deprecated variables"
+- name: "Check deprecated variables: graylog_server_version"
   fail:
     msg: "Varible 'graylog_server_version' has been deprecated. Use 'graylog_full_version' instead."
   when: graylog_server_version is defined
+
+- name: "Check deprecated variables: graylog_install_nginx"
+  fail:
+    msg: "Varible 'graylog_install_nginx' has been deprecated. Use the official Nginx role to install Nginx."
+  when: graylog_install_nginx
 
 - name: "Load OS-family specific vars"
   include_vars: "{{ ansible_os_family }}.yml"


### PR DESCRIPTION
Remove Nginx role dependency, as it's been abandoned and no longer works. Adding documentation instructing users to include the official Nginx role if they need it. Also added a check to throw an error if a user has `graylog_install_nginx` set to `True`. If they have it set to `False`, it will continue as normal.

Fixes #144 