### PR TITLE
Add configuration tag

### DIFF
--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -9,6 +9,7 @@
   fail: msg="Variable '{{ item }}' is not defined"
   when: item not in vars
   with_items: "{{ required_vars }}"
+  tags: configuration
 
 - name: "Check graylog_mongodb_version var"
   fail: msg="The 'graylog_mongodb_version' variable is not defined."
@@ -21,6 +22,7 @@
 
 - name: "Load OS-family specific vars"
   include_vars: "{{ ansible_os_family }}.yml"
+  tags: configuration
 
 - name: "Discover systemd capabilities"
   set_fact:
@@ -30,6 +32,7 @@
         (ansible_distribution in ['RedHat','CentOS'] and ansible_distribution_version is version('7', '>=')) or
         (ansible_distribution == 'Ubuntu' and ansible_distribution_version is version('15', '>='))
       }}
+  tags: configuration
 
 - include: "mongodb-{{ ansible_os_family }}.yml"
   when: graylog_install_mongodb

--- a/tasks/server.yml
+++ b/tasks/server.yml
@@ -30,6 +30,7 @@
     group: "graylog"
     mode: 0644
   notify: "restart graylog-server"
+  tags: configuration
 
 - name: "Graylog server defaults should be configured"
   template:
@@ -39,6 +40,7 @@
     group: "graylog"
     mode: 0644
   notify: "restart graylog-server"
+  tags: configuration
 
 - name: "Graylog server should start after reboot"
   file:


### PR DESCRIPTION
To facilitate the use of the role to push just
configuration changes tags are added at the
appropriate locations.

I don't know if there are some ansible community internal default "tags" for a use case like this.
Maybe graylog_configuration would be a better name for the tag?