### PR TITLE
Add graylog_server_java_opts_extra

### DIFF
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -187,7 +187,8 @@ graylog_web_thread_pool_size:        16
 # JVM
 graylog_gc_warning_threshold: "1s"
 graylog_server_heap_size:     "1500m"
-graylog_server_java_opts:     "-Djava.net.preferIPv4Stack=true -Xms{{ graylog_server_heap_size }} -Xmx{{ graylog_server_heap_size }} -XX:NewRatio=1 -server -XX:+ResizeTLAB -XX:-OmitStackTraceInFastThrow"
+graylog_server_java_opts_extra: ""
+graylog_server_java_opts:     "-Djava.net.preferIPv4Stack=true -Xms{{ graylog_server_heap_size }} -Xmx{{ graylog_server_heap_size }} -XX:NewRatio=1 -server -XX:+ResizeTLAB -XX:-OmitStackTraceInFastThrow {{graylog_server_java_opts_extra}}"
 graylog_server_args:          ""
 graylog_server_wrapper:       ""
 


### PR DESCRIPTION
Allows to add extra variables to the JAVA_OPTS
string, without missing upstream updates.