### PR TITLE
Expose Java path as variable

### DIFF
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -187,6 +187,7 @@ graylog_web_thread_pool_size:        16
 # JVM
 graylog_gc_warning_threshold: "1s"
 graylog_server_heap_size:     "1500m"
+graylog_server_java:          "/usr/bin/java"
 graylog_server_java_opts_extra: ""
 graylog_server_java_opts:     "-Djava.net.preferIPv4Stack=true -Xms{{ graylog_server_heap_size }} -Xmx{{ graylog_server_heap_size }} -XX:NewRatio=1 -server -XX:+ResizeTLAB -XX:-OmitStackTraceInFastThrow {{graylog_server_java_opts_extra}}"
 graylog_server_args:          ""

--- a/templates/graylog.server.default.j2
+++ b/templates/graylog.server.default.j2
@@ -1,4 +1,4 @@
-JAVA=/usr/bin/java
+JAVA="{{ graylog_server_java }}"
 GRAYLOG_SERVER_JAVA_OPTS="{{ graylog_server_java_opts }}"
 GRAYLOG_SERVER_ARGS="{{ graylog_server_args }}"
 GRAYLOG_COMMAND_WRAPPER="{{ graylog_server_wrapper }}"


### PR DESCRIPTION
Allow the Graylog server 'JAVA' environment variable to be customized
using a `graylog_server_java` role variable. The value defaults to
`/usr/bin/java`, which is the existing behavior. This helps use the role
in cases where `/usr/bin/java` is not the desired java executable.