### PR TITLE
Add cluster example playbook

### DIFF
--- a/README.md
+++ b/README.md
@@ -205,7 +205,7 @@ Finally, we install Graylog.
 
 We set `graylog_install_elasticsearch: False` and `graylog_install_mongodb: False` so the Graylog role doesn't try to install Elasticsearch and MongoDB. Those flags are intended for single-instance installs.
 
-The full example can be seen [here](molecule/example2/converge.yml), and our [documentation](https://docs.graylog.org/v1/docs/multinode-setup) has more in-depth advice on configuring a multi-node Graylog setup.
+The full example can be seen [here](molecule/example2/converge.yml). Our [documentation](https://docs.graylog.org/v1/docs/multinode-setup) has more in-depth advice on configuring a multi-node Graylog setup.
 
 
 ## Role Variables

--- a/README.md
+++ b/README.md
@@ -97,6 +97,117 @@ To generate `root_password_sha2`:
       echo -n "Enter Password: " && head -1 </dev/stdin | tr -d '\n' | sha256sum | cut -d" " -f1
 
 
+## Example Playbook - Cluster
+
+Here is an example that deploys a Graylog cluster, like the one mentioned on the [architecture page](https://docs.graylog.org/docs) of our documentation.
+
+In our Ansible hosts file, we have 3 instances for the Elasticsearch cluster and 3 instances for the Graylog cluster:
+
+```
+[elasticsearch]
+elasticsearch01
+elasticsearch02
+elasticsearch03
+
+[graylog]
+graylog01
+graylog02
+graylog03
+```
+
+First, we deploy the [Elasticsearch](https://github.com/elastic/ansible-elasticsearch) cluster. Note that this doesn't configure authentication or HTTPS. For a production instance, you would likely want that.
+
+```yaml
+- hosts: "elasticsearch"
+  vars:
+    es_major_version: "7.x"
+    es_version: "7.10.2"
+    es_enable_xpack: False
+    es_instance_name: "graylog"
+    es_heap_size: "1g"
+    es_config:
+      node.name: "{{ ansible_hostname }}"
+      cluster.name: "graylog"
+      http.port: 9200
+      transport.port: 9300
+      network.host: "0.0.0.0"
+      discovery.seed_hosts: "elasticsearch01:9300, elasticsearch02:9300, elasticsearch03:9300"
+      cluster.initial_master_nodes: "elasticsearch01, elasticsearch02, elasticsearch03"
+    oss_version: True
+    es_action_auto_create_index: False
+
+  roles:
+    - role: "elastic.elasticsearch"
+```
+
+Next, we'll deploy three MongoDB instances and configure them as a Replica Set. This is done with the [MongoDB community collection](https://github.com/ansible-collections/community.mongodb).
+
+These MongoDB instances will live on the Graylog servers, as they are not expected to consume much resources.
+
+Again, this doesn't configure authentication in MongoDB. You may want that for a production cluster.
+
+```yaml
+- hosts: "graylog"
+  vars:
+    mongodb_version: "4.4"
+    bind_ip: "0.0.0.0"
+    repl_set_name: "rs0"
+    authorization: "disabled"
+  roles:
+    - community.mongodb.mongodb_repository
+    - community.mongodb.mongodb_mongod
+  tasks:
+    - name: "Start MongoDB"
+      service:
+        name: "mongod"
+        state: "started"
+        enabled: "yes"
+
+- hosts: "graylog01"
+  tasks:
+    - name: "Install PyMongo"
+      apt:
+        update_cache: yes
+        name: "python3-pymongo"
+        state: "latest"
+    - name: Configure replicaset
+      community.mongodb.mongodb_replicaset:
+        login_host: "localhost"
+        replica_set: "rs0"
+        members:
+        - graylog01
+        - graylog02
+        - graylog03
+      register: repl
+```
+
+Finally, we install Graylog.
+
+```yaml
+- hosts: "graylog"
+  vars:
+    graylog_is_master: "{{ True if ansible_hostname == 'graylog01' else False }}"
+    graylog_version: 4.2
+    graylog_install_java: False
+    graylog_install_elasticsearch: False
+    graylog_install_mongodb: False
+    graylog_password_secret: "" # Insert your own here. Generate with: pwgen -s 96 1
+    graylog_root_password_sha2: "" # Insert your own root_password_sha2 here.
+    graylog_http_bind_address: "{{ ansible_default_ipv4.address }}:9000"
+    graylog_http_publish_uri: "http://{{ ansible_default_ipv4.address }}:9000/"
+    graylog_http_external_uri: "http://{{ ansible_default_ipv4.address }}:9000/"
+    graylog_elasticsearch_hosts: "http://elasticsearch01:9200,http://elasticsearch02:9200,http://elasticsearch03:9200"
+    graylog_mongodb_uri: "mongodb://graylog01:27017,graylog02:27017,graylog03:27017/graylog"
+
+  roles:
+    - role: "graylog2.graylog"
+```
+
+We set `graylog_install_elasticsearch: False` and `graylog_install_mongodb: False` so the Graylog role doesn't try to install Elasticsearch and MongoDB. Those flags are intended for single-instance installs.
+
+The full example can be seen [here](molecule/example2/converge.yml), and our [documentation](https://docs.graylog.org/v1/docs/multinode-setup) has more in-depth advice on configuring a multi-node Graylog setup.
+
+
 ## Role Variables
 
 A list of all available role variables is documented [here](docs/Variables.md).

--- a/molecule/example2/converge.yml
+++ b/molecule/example2/converge.yml
@@ -31,6 +31,7 @@
       discovery.seed_hosts: "elasticsearch01:9300, elasticsearch02:9300, elasticsearch03:9300"
       cluster.initial_master_nodes: "elasticsearch01, elasticsearch02, elasticsearch03"
     oss_version: True
+    es_action_auto_create_index: False
 
   roles:
     - role: "elastic.elasticsearch"

--- a/molecule/example2/converge.yml
+++ b/molecule/example2/converge.yml
@@ -41,12 +41,17 @@
   vars:
     mongodb_version: "4.4"
     bind_ip: "0.0.0.0"
-    config_port: "27019"
-    config_repl_set_name: "rs0"
+    repl_set_name: "rs0"
+    authorization: "disabled"
   roles:
     - community.mongodb.mongodb_repository
-    - community.mongodb.mongodb_install
-    - community.mongodb.mongodb_config
+    - community.mongodb.mongodb_mongod
+  tasks:
+    - name: "Start MongoDB"
+      service:
+        name: "mongod"
+        state: "started"
+        enabled: "yes"
 
 - hosts: "graylog01"
   tasks:
@@ -57,12 +62,13 @@
         state: "latest"
     - name: Configure replicaset
       community.mongodb.mongodb_replicaset:
-        login_host: localhost:27019
-        replica_set: rs0
+        login_host: "localhost"
+        replica_set: "rs0"
         members:
-        - graylog01:27019
-        - graylog02:27019
-        - graylog03:27019
+        - graylog01
+        - graylog02
+        - graylog03
+      register: repl
 
 
 - hosts: "graylog"
@@ -78,7 +84,7 @@
     graylog_http_publish_uri: "http://{{ ansible_default_ipv4.address }}:9000/"
     graylog_http_external_uri: "http://{{ ansible_default_ipv4.address }}:9000/"
     graylog_elasticsearch_hosts: "http://elasticsearch01:9200,http://elasticsearch02:9200,http://elasticsearch03:9200"
-    graylog_mongodb_uri: "mongodb://graylog01:27019,graylog02:27019,graylog03:27019/graylog"
+    graylog_mongodb_uri: "mongodb://graylog01:27017,graylog02:27017,graylog03:27017/graylog"
 
   roles:
     - role: "graylog2.graylog"

--- a/molecule/example2/converge.yml
+++ b/molecule/example2/converge.yml
@@ -14,6 +14,15 @@
         update_cache: "yes"
         name: "gpg-agent"
         state: "latest"
+    - name: "Install ntp"
+      apt:
+        name: "ntp"
+        state: "latest"
+    - name: "Start ntp"
+      service:
+        name: "ntp"
+        state: "started"
+        enabled: "yes"
 
 - hosts: "elasticsearch"
   vars:

--- a/molecule/example2/converge.yml
+++ b/molecule/example2/converge.yml
@@ -41,6 +41,8 @@
   vars:
     mongodb_version: "4.4"
     bind_ip: "0.0.0.0"
+    config_port: "27019"
+    config_repl_set_name: "rs0"
   roles:
     - community.mongodb.mongodb_repository
     - community.mongodb.mongodb_install
@@ -53,14 +55,14 @@
         update_cache: yes
         name: "python3-pymongo"
         state: "latest"
-    - name: Ensure replicaset rs0 exists
+    - name: Configure replicaset
       community.mongodb.mongodb_replicaset:
-        login_host: graylog01
+        login_host: localhost:27019
         replica_set: rs0
         members:
-        - graylog01:27017
-        - graylog02:27017
-        - graylog02:27017
+        - graylog01:27019
+        - graylog02:27019
+        - graylog03:27019
 
 
 - hosts: "graylog"

--- a/molecule/example2/converge.yml
+++ b/molecule/example2/converge.yml
@@ -36,24 +36,9 @@
   roles:
     - role: "elastic.elasticsearch"
 
-- hosts: "graylog_primary"
+- hosts: "graylog"
   vars:
-    graylog_version: 4.2
-    graylog_install_java: False
-    graylog_install_elasticsearch: False
-    graylog_password_secret: "2jueVqZpwLLjaWxV"
-    graylog_root_password_sha2: "8c6976e5b5410415bde908bd4dee15dfb167a9c873fc4bb8a81f6f2ab448a918"
-    graylog_http_bind_address: "{{ ansible_default_ipv4.address }}:9000"
-    graylog_http_publish_uri: "http://{{ ansible_default_ipv4.address }}:9000/"
-    graylog_http_external_uri: "http://{{ ansible_default_ipv4.address }}:9000/"
-    graylog_elasticsearch_hosts: "http://elasticsearch01:9200,http://elasticsearch02:9200,http://elasticsearch03:9200"
-
-  roles:
-    - role: "graylog2.graylog"
-
-- hosts: "graylog_secondary"
-  vars:
-    graylog_is_master: False
+    graylog_is_master: "{{ True if ansible_hostname == 'graylog01' else False }}"
     graylog_version: 4.2
     graylog_install_java: False
     graylog_install_elasticsearch: False

--- a/molecule/example2/converge.yml
+++ b/molecule/example2/converge.yml
@@ -26,7 +26,7 @@
       node.name: "{{ ansible_hostname }}"
       cluster.name: "graylog"
       http.port: 9200
-      transport.tcp.port: 9300
+      transport.port: 9300
       network.host: "0.0.0.0"
       discovery.seed_hosts: "elasticsearch01:9300, elasticsearch02:9300, elasticsearch03:9300"
       cluster.initial_master_nodes: "elasticsearch01, elasticsearch02, elasticsearch03"

--- a/molecule/example2/converge.yml
+++ b/molecule/example2/converge.yml
@@ -1,19 +1,19 @@
 - hosts: "all"
   tasks:
-    - name: Fix missing dir
+    - name: "Fix missing dir"
       file:
-        path: /usr/share/man/man1
-        state: directory
-    - name: Install Java
+        path: "/usr/share/man/man1"
+        state: "directory"
+    - name: "Install Java"
       apt:
         update_cache: yes
-        name: openjdk-8-jre
-        state: latest
-    - name: Install gpg-agent
+        name: "openjdk-8-jre"
+        state: "latest"
+    - name: "Install gpg-agent"
       apt:
-        update_cache: yes
-        name: gpg-agent
-        state: latest
+        update_cache: "yes"
+        name: "gpg-agent"
+        state: "latest"
 
 - hosts: "elasticsearch"
   vars:
@@ -23,27 +23,45 @@
     es_instance_name: "graylog"
     es_heap_size: "1g"
     es_config:
-      node.name: "graylog"
+      node.name: "{{ ansible_hostname }}"
       cluster.name: "graylog"
       http.port: 9200
       transport.tcp.port: 9300
-      network.host: "127.0.0.1"
-      discovery.seed_hosts: "localhost:9300"
-      cluster.initial_master_nodes: "graylog"
+      network.host: "0.0.0.0"
+      discovery.seed_hosts: "elasticsearch01:9300, elasticsearch02:9300, elasticsearch03:9300"
+      cluster.initial_master_nodes: "elasticsearch01, elasticsearch02, elasticsearch03"
     oss_version: True
 
   roles:
     - role: "elastic.elasticsearch"
 
-- hosts: "graylog"
+- hosts: "graylog_primary"
   vars:
     graylog_version: 4.2
     graylog_install_java: False
+    graylog_install_elasticsearch: False
     graylog_password_secret: "2jueVqZpwLLjaWxV"
     graylog_root_password_sha2: "8c6976e5b5410415bde908bd4dee15dfb167a9c873fc4bb8a81f6f2ab448a918"
     graylog_http_bind_address: "{{ ansible_default_ipv4.address }}:9000"
     graylog_http_publish_uri: "http://{{ ansible_default_ipv4.address }}:9000/"
     graylog_http_external_uri: "http://{{ ansible_default_ipv4.address }}:9000/"
+    graylog_elasticsearch_hosts: "http://elasticsearch01:9200,http://elasticsearch02:9200,http://elasticsearch03:9200"
+
+  roles:
+    - role: "graylog2.graylog"
+
+- hosts: "graylog_secondary"
+  vars:
+    graylog_is_master: False
+    graylog_version: 4.2
+    graylog_install_java: False
+    graylog_install_elasticsearch: False
+    graylog_password_secret: "2jueVqZpwLLjaWxV"
+    graylog_root_password_sha2: "8c6976e5b5410415bde908bd4dee15dfb167a9c873fc4bb8a81f6f2ab448a918"
+    graylog_http_bind_address: "{{ ansible_default_ipv4.address }}:9000"
+    graylog_http_publish_uri: "http://{{ ansible_default_ipv4.address }}:9000/"
+    graylog_http_external_uri: "http://{{ ansible_default_ipv4.address }}:9000/"
+    graylog_elasticsearch_hosts: "http://elasticsearch01:9200,http://elasticsearch02:9200,http://elasticsearch03:9200"
 
   roles:
     - role: "graylog2.graylog"

--- a/molecule/example2/converge.yml
+++ b/molecule/example2/converge.yml
@@ -38,16 +38,26 @@
 
 - hosts: "graylog"
   vars:
+    mongodb_version: "4.4"
+    mongodb_net_bindip: "0.0.0.0"
+    mongodb_replication_replset: "rs0"
+  roles:
+    - role: "undergreen.mongodb"
+
+- hosts: "graylog"
+  vars:
     graylog_is_master: "{{ True if ansible_hostname == 'graylog01' else False }}"
     graylog_version: 4.2
     graylog_install_java: False
     graylog_install_elasticsearch: False
+    graylog_install_mongodb: False
     graylog_password_secret: "2jueVqZpwLLjaWxV"
     graylog_root_password_sha2: "8c6976e5b5410415bde908bd4dee15dfb167a9c873fc4bb8a81f6f2ab448a918"
     graylog_http_bind_address: "{{ ansible_default_ipv4.address }}:9000"
     graylog_http_publish_uri: "http://{{ ansible_default_ipv4.address }}:9000/"
     graylog_http_external_uri: "http://{{ ansible_default_ipv4.address }}:9000/"
     graylog_elasticsearch_hosts: "http://elasticsearch01:9200,http://elasticsearch02:9200,http://elasticsearch03:9200"
+    graylog_mongodb_uri: "mongodb://graylog01:27017,graylog02:27017,graylog03:27017/graylog"
 
   roles:
     - role: "graylog2.graylog"

--- a/molecule/example2/converge.yml
+++ b/molecule/example2/converge.yml
@@ -78,7 +78,7 @@
     graylog_http_publish_uri: "http://{{ ansible_default_ipv4.address }}:9000/"
     graylog_http_external_uri: "http://{{ ansible_default_ipv4.address }}:9000/"
     graylog_elasticsearch_hosts: "http://elasticsearch01:9200,http://elasticsearch02:9200,http://elasticsearch03:9200"
-    graylog_mongodb_uri: "mongodb://graylog01:27017,graylog02:27017,graylog03:27017/graylog"
+    graylog_mongodb_uri: "mongodb://graylog01:27019,graylog02:27019,graylog03:27019/graylog"
 
   roles:
     - role: "graylog2.graylog"

--- a/molecule/example2/converge.yml
+++ b/molecule/example2/converge.yml
@@ -1,0 +1,49 @@
+- hosts: "all"
+  tasks:
+    - name: Fix missing dir
+      file:
+        path: /usr/share/man/man1
+        state: directory
+    - name: Install Java
+      apt:
+        update_cache: yes
+        name: openjdk-8-jre
+        state: latest
+    - name: Install gpg-agent
+      apt:
+        update_cache: yes
+        name: gpg-agent
+        state: latest
+
+- hosts: "elasticsearch"
+  vars:
+    es_major_version: "7.x"
+    es_version: "7.10.2"
+    es_enable_xpack: False
+    es_instance_name: "graylog"
+    es_heap_size: "1g"
+    es_config:
+      node.name: "graylog"
+      cluster.name: "graylog"
+      http.port: 9200
+      transport.tcp.port: 9300
+      network.host: "127.0.0.1"
+      discovery.seed_hosts: "localhost:9300"
+      cluster.initial_master_nodes: "graylog"
+    oss_version: True
+
+  roles:
+    - role: "elastic.elasticsearch"
+
+- hosts: "graylog"
+  vars:
+    graylog_version: 4.2
+    graylog_install_java: False
+    graylog_password_secret: "2jueVqZpwLLjaWxV"
+    graylog_root_password_sha2: "8c6976e5b5410415bde908bd4dee15dfb167a9c873fc4bb8a81f6f2ab448a918"
+    graylog_http_bind_address: "{{ ansible_default_ipv4.address }}:9000"
+    graylog_http_publish_uri: "http://{{ ansible_default_ipv4.address }}:9000/"
+    graylog_http_external_uri: "http://{{ ansible_default_ipv4.address }}:9000/"
+
+  roles:
+    - role: "graylog2.graylog"

--- a/molecule/example2/converge.yml
+++ b/molecule/example2/converge.yml
@@ -36,13 +36,32 @@
   roles:
     - role: "elastic.elasticsearch"
 
+
 - hosts: "graylog"
   vars:
     mongodb_version: "4.4"
-    mongodb_net_bindip: "0.0.0.0"
-    mongodb_replication_replset: "rs0"
+    bind_ip: "0.0.0.0"
   roles:
-    - role: "undergreen.mongodb"
+    - community.mongodb.mongodb_repository
+    - community.mongodb.mongodb_install
+    - community.mongodb.mongodb_config
+
+- hosts: "graylog01"
+  tasks:
+    - name: "Install PyMongo"
+      apt:
+        update_cache: yes
+        name: "python3-pymongo"
+        state: "latest"
+    - name: Ensure replicaset rs0 exists
+      community.mongodb.mongodb_replicaset:
+        login_host: graylog01
+        replica_set: rs0
+        members:
+        - graylog01:27017
+        - graylog02:27017
+        - graylog02:27017
+
 
 - hosts: "graylog"
   vars:

--- a/molecule/example2/molecule.yml
+++ b/molecule/example2/molecule.yml
@@ -9,33 +9,45 @@ platforms:
     command: '/sbin/init'
     volumes:
       - /sys/fs/cgroup:/sys/fs/cgroup:ro
+    networks:
+      - name: "graylog"
+    network_mode: "graylog"
     privileged: true
     pre_build_image: true
     groups:
-      - graylog
+      - graylog_primary
   - name: graylog02
     image: geerlingguy/docker-ubuntu2004-ansible
     command: '/sbin/init'
     volumes:
       - /sys/fs/cgroup:/sys/fs/cgroup:ro
+    networks:
+      - name: "graylog"
+    network_mode: "graylog"
     privileged: true
     pre_build_image: true
     groups:
-      - graylog
+      - graylog_secondary
   - name: graylog03
     image: geerlingguy/docker-ubuntu2004-ansible
     command: '/sbin/init'
     volumes:
       - /sys/fs/cgroup:/sys/fs/cgroup:ro
+    networks:
+      - name: "graylog"
+    network_mode: "graylog"
     privileged: true
     pre_build_image: true
     groups:
-      - graylog
+      - graylog_secondary
   - name: elasticsearch01
     image: geerlingguy/docker-ubuntu2004-ansible
     command: '/sbin/init'
     volumes:
       - /sys/fs/cgroup:/sys/fs/cgroup:ro
+    networks:
+      - name: "graylog"
+    network_mode: "graylog"
     privileged: true
     pre_build_image: true
     groups:
@@ -45,6 +57,9 @@ platforms:
     command: '/sbin/init'
     volumes:
       - /sys/fs/cgroup:/sys/fs/cgroup:ro
+    networks:
+      - name: "graylog"
+    network_mode: "graylog"
     privileged: true
     pre_build_image: true
     groups:
@@ -54,6 +69,9 @@ platforms:
     command: '/sbin/init'
     volumes:
       - /sys/fs/cgroup:/sys/fs/cgroup:ro
+    networks:
+      - name: "graylog"
+    network_mode: "graylog"
     privileged: true
     pre_build_image: true
     groups:

--- a/molecule/example2/molecule.yml
+++ b/molecule/example2/molecule.yml
@@ -11,6 +11,8 @@ platforms:
       - /sys/fs/cgroup:/sys/fs/cgroup:ro
     networks:
       - name: "graylog"
+    published_ports:
+      - "0.0.0.0:9000:9000/tcp"
     network_mode: "graylog"
     privileged: true
     pre_build_image: true
@@ -23,6 +25,8 @@ platforms:
       - /sys/fs/cgroup:/sys/fs/cgroup:ro
     networks:
       - name: "graylog"
+    published_ports:
+      - "0.0.0.0:9001:9000/tcp"
     network_mode: "graylog"
     privileged: true
     pre_build_image: true
@@ -35,6 +39,8 @@ platforms:
       - /sys/fs/cgroup:/sys/fs/cgroup:ro
     networks:
       - name: "graylog"
+    published_ports:
+      - "0.0.0.0:9002:9000/tcp"
     network_mode: "graylog"
     privileged: true
     pre_build_image: true

--- a/molecule/example2/molecule.yml
+++ b/molecule/example2/molecule.yml
@@ -11,9 +11,9 @@ platforms:
       - /sys/fs/cgroup:/sys/fs/cgroup:ro
     networks:
       - name: "graylog"
+    network_mode: "graylog"
     published_ports:
       - "0.0.0.0:9000:9000/tcp"
-    network_mode: "graylog"
     privileged: true
     pre_build_image: true
     groups:
@@ -25,9 +25,9 @@ platforms:
       - /sys/fs/cgroup:/sys/fs/cgroup:ro
     networks:
       - name: "graylog"
+    network_mode: "graylog"
     published_ports:
       - "0.0.0.0:9001:9000/tcp"
-    network_mode: "graylog"
     privileged: true
     pre_build_image: true
     groups:
@@ -39,9 +39,9 @@ platforms:
       - /sys/fs/cgroup:/sys/fs/cgroup:ro
     networks:
       - name: "graylog"
+    network_mode: "graylog"
     published_ports:
       - "0.0.0.0:9002:9000/tcp"
-    network_mode: "graylog"
     privileged: true
     pre_build_image: true
     groups:

--- a/molecule/example2/molecule.yml
+++ b/molecule/example2/molecule.yml
@@ -17,7 +17,7 @@ platforms:
     privileged: true
     pre_build_image: true
     groups:
-      - graylog_primary
+      - graylog
   - name: graylog02
     image: geerlingguy/docker-ubuntu2004-ansible
     command: '/sbin/init'
@@ -31,7 +31,7 @@ platforms:
     privileged: true
     pre_build_image: true
     groups:
-      - graylog_secondary
+      - graylog
   - name: graylog03
     image: geerlingguy/docker-ubuntu2004-ansible
     command: '/sbin/init'
@@ -45,7 +45,7 @@ platforms:
     privileged: true
     pre_build_image: true
     groups:
-      - graylog_secondary
+      - graylog
   - name: elasticsearch01
     image: geerlingguy/docker-ubuntu2004-ansible
     command: '/sbin/init'

--- a/molecule/example2/molecule.yml
+++ b/molecule/example2/molecule.yml
@@ -1,0 +1,62 @@
+---
+dependency:
+  name: galaxy
+driver:
+  name: docker
+platforms:
+  - name: graylog01
+    image: geerlingguy/docker-ubuntu2004-ansible
+    command: '/sbin/init'
+    volumes:
+      - /sys/fs/cgroup:/sys/fs/cgroup:ro
+    privileged: true
+    pre_build_image: true
+    groups:
+      - graylog
+  - name: graylog02
+    image: geerlingguy/docker-ubuntu2004-ansible
+    command: '/sbin/init'
+    volumes:
+      - /sys/fs/cgroup:/sys/fs/cgroup:ro
+    privileged: true
+    pre_build_image: true
+    groups:
+      - graylog
+  - name: graylog03
+    image: geerlingguy/docker-ubuntu2004-ansible
+    command: '/sbin/init'
+    volumes:
+      - /sys/fs/cgroup:/sys/fs/cgroup:ro
+    privileged: true
+    pre_build_image: true
+    groups:
+      - graylog
+  - name: elasticsearch01
+    image: geerlingguy/docker-ubuntu2004-ansible
+    command: '/sbin/init'
+    volumes:
+      - /sys/fs/cgroup:/sys/fs/cgroup:ro
+    privileged: true
+    pre_build_image: true
+    groups:
+      - elasticsearch
+  - name: elasticsearch02
+    image: geerlingguy/docker-ubuntu2004-ansible
+    command: '/sbin/init'
+    volumes:
+      - /sys/fs/cgroup:/sys/fs/cgroup:ro
+    privileged: true
+    pre_build_image: true
+    groups:
+      - elasticsearch
+  - name: elasticsearch03
+    image: geerlingguy/docker-ubuntu2004-ansible
+    command: '/sbin/init'
+    volumes:
+      - /sys/fs/cgroup:/sys/fs/cgroup:ro
+    privileged: true
+    pre_build_image: true
+    groups:
+      - elasticsearch
+provisioner:
+  name: ansible


### PR DESCRIPTION
Adding an example playbook to demonstrate a cluster install. 

**Testing the playbook**

```
virtualenv venv
source venv/bin/activate
python3 -m pip install -U pip
pip3 install -r requirements.txt
molecule create --scenario-name=example2
molecule converge --scenario-name=example2
molecule list
molecule login --scenario-name=example2 -h graylog01
```

Fixes #89 

Reference:
- https://docs.graylog.org/v1/docs/multinode-setup

