### PR TITLE
 [+] Add a initial content pack settings

### DIFF
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -120,7 +120,7 @@ graylog_elasticsearch_connect_timeout:                  "10s"
 # Content packs
 graylog_content_packs_loader_enabled: True
 graylog_content_packs_dir:            "/usr/share/graylog-server/contentpacks"
-graylog_content_packs_auto_load:      ""
+graylog_content_packs_auto_install:      ""
 
 # Buffer
 graylog_udp_recvbuffer_sizes:                          1048576

--- a/templates/graylog.server.conf.j2
+++ b/templates/graylog.server.conf.j2
@@ -656,6 +656,17 @@ dashboard_widget_default_cache_time = {{ graylog_dashboard_widget_default_cache_
 # Should be http_thread_pool_size * average_cluster_size if you have a high number of concurrent users.
 proxied_requests_thread_pool_size = {{ graylog_proxied_requests_thread_pool_size }}
 
+# Automatically load content packs in "content_packs_dir" on the first start of Graylog.
+content_packs_loader_enabled = {{ graylog_content_packs_loader_enabled }}
+
+# The directory which contains content packs which should be loaded on the first start of Graylog.
+content_packs_dir = {{ graylog_content_packs_dir }}
+
+# A comma-separated list of content packs (files in "content_packs_dir") which should be applied on
+# the first start of Graylog.
+# Default: empty
+content_packs_auto_load = {{ graylog_content_packs_auto_load }}
+
 {% for key, value in graylog_additional_config.items() %}
 {{ key }} = {{ value }}
 {% endfor %}

--- a/templates/graylog.server.conf.j2
+++ b/templates/graylog.server.conf.j2
@@ -665,7 +665,7 @@ content_packs_dir = {{ graylog_content_packs_dir }}
 # A comma-separated list of content packs (files in "content_packs_dir") which should be applied on
 # the first start of Graylog.
 # Default: empty
-content_packs_auto_load = {{ graylog_content_packs_auto_load }}
+content_packs_auto_install = {{ graylog_content_packs_auto_install }}
 
 {% for key, value in graylog_additional_config.items() %}
 {{ key }} = {{ value }}


### PR DESCRIPTION
Hi, there. 

I noticed a lack of configuration in templates/graylog.server.conf.j2. So I propose this configuration when I referenced  [[git.codificar.com.br/diogo.coutinho] this config](https://git.codificar.com.br/diogo.coutinho/laradock-multi-projetos/blob/master/graylog/config/graylog.conf).

Detail; The add settings are not contained the template of graylog.server.conf.j2 whether contained the default config parameter [defaults/main.yml#L120-L123](https://github.com/Graylog2/graylog-ansible-role/blob/648669639d995478d916e60c609d49bc5d983b58/defaults/main.yml#L120-L123).

My Graylog version is 4.2. If it needs to consider under the 3.0 version for lower compatibility, Let me know it. And if you have some idea, could you tell me it?

## Notes for Reviewers

- [ ] The commit history must be preserved - please use the rebase-merge or standard merge option instead of squash-merge
- [ ] Sync up with the author before merging