### PR TITLE
allow configuring elasticsearch_discovery_filter by uncommenting var

### DIFF
--- a/templates/graylog.server.conf.j2
+++ b/templates/graylog.server.conf.j2
@@ -247,7 +247,7 @@ elasticsearch_discovery_enabled = {{ graylog_elasticsearch_discovery_enabled }}
 # see https://www.elastic.co/guide/en/elasticsearch/reference/5.4/cluster.html#cluster-nodes
 #
 # Default: empty
-#elasticsearch_discovery_filter = {{ graylog_elasticsearch_discovery_filter }}
+elasticsearch_discovery_filter = {{ graylog_elasticsearch_discovery_filter }}
 
 # Frequency of the Elasticsearch node discovery.
 #


### PR DESCRIPTION
elasticsearch_discovery_filter is commented in graylog configuration template so any configuration of this var is not applicable.
