### PR TITLE
Add basic Oracle Linux 7+ support

### DIFF
--- a/molecule/ci/converge.yml
+++ b/molecule/ci/converge.yml
@@ -28,7 +28,7 @@
         name:
           - java-1.8.0-openjdk
         state: latest
-      when: ansible_distribution == 'CentOS' or ansible_distribution == 'Red Hat Enterprise Linux'
+      when: ansible_distribution == 'CentOS' or ansible_distribution == 'Red Hat Enterprise Linux' or ansible_distribution == 'OracleLinux'
 
 - hosts: "all"
   vars:

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -34,7 +34,7 @@
     use_system_d: >
       {{
         (ansible_distribution == 'Debian' and ansible_distribution_version is version('8', '>=')) or
-        (ansible_distribution in ['RedHat','CentOS'] and ansible_distribution_version is version('7', '>=')) or
+        (ansible_distribution in ['RedHat','CentOS','OracleLinux'] and ansible_distribution_version is version('7', '>=')) or
         (ansible_distribution == 'Ubuntu' and ansible_distribution_version is version('15', '>='))
       }}
   tags: configuration


### PR DESCRIPTION
Adds basic support for Oracle Linux 7 in tasks that run for RedHat-family distributions. This primarily fixes an issue with MongoDB's systemd unit file not being correct in Oracle Linux 7.

## Notes for Reviewers

- [ ] The commit history must be preserved - please use the rebase-merge or standard merge option instead of squash-merge
- [ ] Sync up with the author before merging

