### PR TITLE
Integrate new packaging into the role and usage of bundled openjdk

### DIFF
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -187,7 +187,7 @@ graylog_web_thread_pool_size:        16
 # JVM
 graylog_gc_warning_threshold: "1s"
 graylog_server_heap_size:     "1500m"
-graylog_server_java:          "/usr/bin/java"
+graylog_server_java:          "/usr/bin/java" # For usage of the bundled openjdk version within graylog leave varviable blank
 graylog_server_java_opts_extra: ""
 graylog_server_java_opts:     "-Djava.net.preferIPv4Stack=true -Xms{{ graylog_server_heap_size }} -Xmx{{ graylog_server_heap_size }} -XX:NewRatio=1 -server -XX:+ResizeTLAB -XX:-OmitStackTraceInFastThrow {{graylog_server_java_opts_extra}}"
 graylog_server_args:          ""
@@ -202,10 +202,18 @@ graylog_install_java:          True
 # Disable steps which break tests
 graylog_not_testing:           True
 
-# Plugins
+# Plugins for Graylog Versions <5.0
 graylog_install_enterprise_plugins:               False
 graylog_install_integrations_plugins:             False
 graylog_install_enterprise_integrations_plugins:  False
+
+# package version for Graylog Version >=5.0
+graylog_install_enterprise_package: False
+graylog_install_open_package:       True
+
+# Graylog Version to install
+graylog_version: 5.0
+graylog_full_version: ""
 
 graylog_additional_config: {}
 

--- a/tasks/setup-Debian.yml
+++ b/tasks/setup-Debian.yml
@@ -28,6 +28,21 @@
   apt:
     name: "graylog-server{% if graylog_full_version is defined %}={{ graylog_full_version }}{% endif %}"
     state: "{{ graylog_package_state }}"
+  when: (graylog_install_enterprise_package | bool == false and graylog_version is version('5.0', '<'))
+  notify: "restart graylog-server"
+
+- name: "Graylog Open server package should be installed"
+  apt:
+    name: "graylog-server{% if graylog_full_version is defined %}={{ graylog_full_version }}{% endif %}"
+    state: "{{ graylog_package_state }}"
+  when: (graylog_install_enterprise_package | bool == false and graylog_version is version('5.0', '>='))
+  notify: "restart graylog-server"
+
+- name: "Graylog Enterprise server package should be installed"
+  apt:
+    name: "graylog-enterprise{% if graylog_full_version is defined %}={{ graylog_full_version }}{% endif %}"
+    state: "{{ graylog_package_state }}"
+  when: (graylog_install_enterprise_package | bool == true and graylog_version is version('5.0', '>='))
   notify: "restart graylog-server"
 
 - name: "setup-Debian.yml | Set elasticsearch priority to {{ graylog_es_debian_pin_version }} apt_preferences"

--- a/tasks/setup-RedHat.yml
+++ b/tasks/setup-RedHat.yml
@@ -12,7 +12,22 @@
   yum:
     name: "graylog-server{% if graylog_full_version is defined %}-{{ graylog_full_version }}{% endif %}"
     state: "{{ graylog_package_state }}"
-  notify: restart graylog-server
+  when: (graylog_install_enterprise_package | bool == false and graylog_version is version('5.0', '<'))
+  notify: "restart graylog-server"
+
+- name: "Graylog Open server package should be installed"
+  yum:
+    name: "graylog-server{% if graylog_full_version is defined %}-{{ graylog_full_version }}{% endif %}"
+    state: "{{ graylog_package_state }}"
+  when: (graylog_install_enterprise_package | bool == false and graylog_version is version('5.0', '>='))
+  notify: "restart graylog-server"
+
+- name: "Graylog Enterprise server package should be installed"
+  yum:
+    name: "graylog-enterprise{% if graylog_full_version is defined %}-{{ graylog_full_version }}{% endif %}"
+    state: "{{ graylog_package_state }}"
+  when: (graylog_install_enterprise_package | bool == true and graylog_version is version('5.0', '>='))
+  notify: "restart graylog-server"
 
 - name: "Installing graylog-enterprise-plugins"
   yum:

--- a/templates/graylog.server.default.j2
+++ b/templates/graylog.server.default.j2
@@ -1,4 +1,6 @@
+{% if graylog_server_java is defined and graylog_server_java|length %}
 JAVA="{{ graylog_server_java }}"
+{% endif %}
 GRAYLOG_SERVER_JAVA_OPTS="{{ graylog_server_java_opts }}"
 GRAYLOG_SERVER_ARGS="{{ graylog_server_args }}"
 GRAYLOG_COMMAND_WRAPPER="{{ graylog_server_wrapper }}"


### PR DESCRIPTION
# Integration von new packaging

Integration of new packaging with the usage of booleans for open and enterprise package. Methods make graylog_full_version no longer optional.

# Integrate usage of bundled jdk version

Make the usage of the bundled jdk version possible with leaving the java-home enviroment binary path empty.

