### PR TITLE
Update tasks/main.yml due to ansible deprecation of include

### DIFF
--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -39,9 +39,9 @@
       }}
   tags: configuration
 
-- include: "mongodb-{{ ansible_os_family }}.yml"
+- include_tasks: "mongodb-{{ ansible_os_family }}.yml"
   when: graylog_install_mongodb
 
-- include: "setup-{{ ansible_os_family }}.yml"
+- include_tasks: "setup-{{ ansible_os_family }}.yml"
 
-- include: "server.yml"
+- include_tasks: "server.yml"


### PR DESCRIPTION
Solving ansible deprecation from include to include_tasks

Closes #198 

## Notes for Reviewers

- [ ] The commit history must be preserved - please use the rebase-merge or standard merge option instead of squash-merge
- [ ] Sync up with the author before merging

